### PR TITLE
Fix graphiql

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount GraphiQL::Rails::Engine, at: '/graphiql'
+  mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
 
   root 'standalone#portal'
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ guide you through the process.
 
    ```bash
    git clone git@github.com:zendesk/volunteer_portal.git
-   cd volunteer
+   cd volunteer_portal
    ```
 
 1. Install the right version of ruby and node


### PR DESCRIPTION
### Context

Latest [graphql-rails](https://github.com/rmosolgo/graphiql-rails) requires a second parameter `graphql_path`, without which 500 error would be thrown:

Production:
![image](https://user-images.githubusercontent.com/3624869/40720441-54504fec-6449-11e8-96ef-d987bc64169d.png)

Development:
![image](https://user-images.githubusercontent.com/3624869/40720522-9ee296dc-6449-11e8-8ca7-a09daf5e7934.png)

After:
![image](https://user-images.githubusercontent.com/3624869/40721046-f8d9a580-644a-11e8-8008-a5afd14805c0.png)

### Approach

Fix the error.

I've followed the normal practice to enable `/graphiql` for development only. Please let me know if opening it up on production was intentional. 😄 I will revert the changes if so.