### PR TITLE
add the deleteEvent mutation

### DIFF
--- a/app/graph/resolvers/event_resolver.rb
+++ b/app/graph/resolvers/event_resolver.rb
@@ -20,6 +20,13 @@ module EventResolver
       event
     end
 
+    def delete(_, args, context)
+      event = Event.find(args['id'])
+      event.destroy!
+
+      event
+    end
+
     private
 
     def update_fields(event, attrs)

--- a/app/graph/types/mutation_graph_type.rb
+++ b/app/graph/types/mutation_graph_type.rb
@@ -159,6 +159,11 @@ MutationGraphType = GraphQL::ObjectType.define do
     resolve EventResolver.method(:update)
   end
 
+  field :deleteEvent, EventGraphType do
+    argument :id, !types.ID
+    resolve EventResolver.method(:delete)
+  end
+
   field :createEventType, EventTypeGraphType do
     argument :input, EditEventTypeInputType
     resolve EventTypeResolver.method(:create)

--- a/test/graph/resolvers/event_resolver_test.rb
+++ b/test/graph/resolvers/event_resolver_test.rb
@@ -59,4 +59,17 @@ describe EventResolver do
       assert_equal timestamp.to_s(:db), e.starts_at.to_s(:db)
     end
   end
+
+  describe '.delete' do
+    let(:event) { events(:minimum) }
+
+    it 'deletes the event' do
+      id = event.id
+      args = { 'id' => id }
+
+      EventResolver.delete(nil, args, nil)
+
+      assert_nil Event.find_by(id: id)
+    end
+  end
 end


### PR DESCRIPTION
Currently the UI issues a `deleteEvent` mutation, but that isn't in the schema so it silently fails. This adds the mutation. 

/cc @zendesk/volunteer 