### PR TITLE
Scope user uniqueness check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
 
   before_validation :set_defaults, on: :create
 
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, uniqueness: { scope: :deleted_at }
 
   validates :office, presence: true
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -18,6 +18,12 @@ describe User do
     it 'is valid' do
       assert_valid user
     end
+
+    it 'does not count soft deleted users for uniqueness' do
+      u2 = user.dup
+      user.soft_delete
+      assert u2.save
+    end
   end
 
   describe '#full_name' do


### PR DESCRIPTION
We're soft deleting users but not properly scoping our uniqueness validation to take that into an account.  We have a user who was soft deleted, and now can't sign back up because the email says it's already taken.

@zendesk/volunteer 