### PR TITLE
Remove dupe dev instructions to install node. Can rely on nvm step above

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,10 +62,6 @@ guide you through the process.
    psql -c 'CREATE ROLE volunteer WITH LOGIN SUPERUSER'
    ```
 
-1. Install Node+NPM
-
-   https://docs.npmjs.com/getting-started/installing-node
-
 1. Copy the `.env.development.example` file to `.env.development`
 
    ```bash


### PR DESCRIPTION
Now that nvm is included as a dev install instruction, we don't need to ask to install node manually