### PR TITLE
Fix Edit Form for Individual Events

### DIFF
--- a/app/javascript/pages/IndividualEvents/index.js
+++ b/app/javascript/pages/IndividualEvents/index.js
@@ -344,11 +344,12 @@ const IndividualEvents = props => {
 const mapStateToProps = (state, _ownProps) => {
   const { popover } = state.model
   const { locationBeforeTransitions } = state.routing
-
-  return {
+  const props = {
     popover,
     locationBeforeTransitions,
   }
+
+  return R.isNil(popover) ? props : R.merge({ initialValues: popover.data }, props)
 }
 
 const formDataToIndividualEventInput = data => {

--- a/app/javascript/pages/IndividualEvents/index.js
+++ b/app/javascript/pages/IndividualEvents/index.js
@@ -379,6 +379,23 @@ const individualEventInputToOptimisticResponse = (data, input) => {
   }
 }
 
+const buildOptimisticResponse = (newEvent, currentUser) => {
+  const { id: currentUserId, individualEvents: existingEvents } = currentUser
+  const arrIdx = R.find(R.propEq('id', newEvent.id), existingEvents)
+  const individualEvents = R.isNil(arrIdx)
+    ? R.append(newEvent, existingEvents)
+    : R.update(arrIdx, newEvent, existingEvents)
+
+  return {
+    __typename: 'Mutation',
+    createEditIndividualEvent: {
+      __typename: 'User',
+      id: currentUserId,
+      individualEvents,
+    },
+  }
+}
+
 const withData = compose(
   graphql(IndividualEventsQuery, {
     options: {
@@ -394,14 +411,7 @@ const withData = compose(
 
         return mutate({
           variables: { input: individualEventInput },
-          optimisticResponse: {
-            __typename: 'Mutation',
-            createEditIndividualEvent: {
-              __typename: 'User',
-              id: currentUser.id,
-              individualEvents: R.append(newEvent, currentUser.individualEvents),
-            },
-          },
+          optimisticResponse: buildOptimisticResponse(newEvent, currentUser),
         })
       },
     }),


### PR DESCRIPTION
This PR proposes two fixes to the edit form for individual events

- Fix form population for individual event edit form. #23 
- Fix optimistic UI for the edit form. Previously, the newly (created *or edited*) event is always appended to the list of existing events. This leads to duplicate events in the list in the case of edits.