### PR TITLE
Sort events by descending

### DIFF
--- a/app/graph/resolvers/event_resolver.rb
+++ b/app/graph/resolvers/event_resolver.rb
@@ -1,5 +1,10 @@
 module EventResolver
   class << self
+    def all(_, args, _)
+      scope = Event.all
+      scope = scope_with_sort_by(scope, args[:sortBy])
+    end
+
     def create(_, args, context)
       attrs = args[:input].to_h
 
@@ -39,6 +44,15 @@ module EventResolver
       event.capacity = attrs['capacity']
       event.starts_at = Time.parse(attrs['startsAt'])
       event.ends_at = Time.parse(attrs['endsAt'])
+    end
+
+    def scope_with_sort_by(scope, sort_by)
+      return scope if sort_by.nil?
+
+      # Makes an ORDER BY string if it follows format of "[column_name]_[order]"
+      # For example: "STARTS_AT_DESC" -> "starts_at DESC"
+      query_string = [sort_by.rpartition('_').first.downcase, sort_by.rpartition('_').last].join ' '
+      scope.order(query_string)
     end
   end
 end

--- a/app/graph/resolvers/event_resolver.rb
+++ b/app/graph/resolvers/event_resolver.rb
@@ -64,10 +64,12 @@ module EventResolver
 
     def scope_with_sort_by(scope, sort_by)
       return scope if sort_by.nil?
-
-      # Makes an ORDER BY string if it follows format of "[column_name]_[order]"
-      # For example: "STARTS_AT_DESC" -> "starts_at DESC"
-      query_string = [sort_by.rpartition('_').first.downcase, sort_by.rpartition('_').last].join ' '
+      query_string = case sort_by
+      when STARTS_AT_DESC
+        'starts_at DESC'
+      when STARTS_AT_ASC
+        'starts_at ASC'
+      end
       scope.order(query_string)
     end
   end

--- a/app/graph/resolvers/event_resolver.rb
+++ b/app/graph/resolvers/event_resolver.rb
@@ -1,8 +1,24 @@
 module EventResolver
+  STARTS_AT_DESC = 'STARTS_AT_DESC'.freeze
+  STARTS_AT_ASC = 'STARTS_AT_ASC'.freeze
+
   class << self
-    def all(_, args, _)
-      scope = Event.all
-      scope = scope_with_sort_by(scope, args[:sortBy])
+    def all(_, args, context)
+      office_id = case args[:officeId]
+      when 'all'
+        nil
+      when 'current'
+        context[:current_user].office_id
+      else
+        args[:officeId]
+      end
+
+      events = Event.all
+      events = events.for_office(office_id)          if office_id
+      events = events.before(Time.at(args[:before])) if args[:before]
+      events = events.after(Time.at(args[:after]))   if args[:after]
+      events = scope_with_sort_by(events, args[:sortBy])
+      events
     end
 
     def create(_, args, context)

--- a/app/graph/types/query_graph_type.rb
+++ b/app/graph/types/query_graph_type.rb
@@ -6,6 +6,14 @@ UserSortEnum = GraphQL::EnumType.define do
   value UserResolver::HOURS_ASC, 'Sort users by volunteering hours in ascending order'
 end
 
+EventSortEnum = GraphQL::EnumType.define do
+  name 'EventSortEnum'
+  description 'How to sort the resulting list of events'
+
+  value EventResolver::STARTS_AT_DESC, 'Sort events by start time in descending order'
+  value EventResolver::STARTS_AT_ASC, 'Sort events by start time in ascending order'
+end
+
 QueryGraphType = GraphQL::ObjectType.define do
   name 'Query'
   description 'The query root for this schema'
@@ -35,23 +43,9 @@ QueryGraphType = GraphQL::ObjectType.define do
     argument :officeId, types.ID,  'the officeId the events belong to, can be set to "current" to use the current users office id'
     argument :after,    types.Int, 'earliest start time allowed'
     argument :before,   types.Int, 'latest start time allowed'
+    argument :sortBy,   EventSortEnum
 
-    resolve -> (_, args, context) do
-      office_id = case args[:officeId]
-      when 'all'
-        nil
-      when 'current'
-        context[:current_user].office_id
-      else
-        args[:officeId]
-      end
-
-      events = Event.all
-      events = events.for_office(office_id)          if office_id
-      events = events.before(Time.at(args[:before])) if args[:before]
-      events = events.after(Time.at(args[:after]))   if args[:after]
-      events
-    end
+    resolve EventResolver.method(:all)
   end
 
   field :user do

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -19,6 +19,8 @@ import s from './main.css'
 
 import 'style-loader!css-loader!react-table/react-table.css'
 
+const eventsSort = 'STARTS_AT_ASC'
+
 const actionLinks = (event, deleteEvent) => (
   <div className={s.actionColumn}>
     <Link to={`/portal/admin/events/${event.id}/edit`}>Edit</Link>
@@ -159,6 +161,7 @@ const withData = compose(
     options: ({ adminOfficeFilter: { value: officeId = 'current' } }) => ({
       variables: {
         officeId: officeId,
+        sortBy: eventsSort,
       },
       fetchPolicy: 'cache-and-network',
     }),

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -19,7 +19,7 @@ import s from './main.css'
 
 import 'style-loader!css-loader!react-table/react-table.css'
 
-const eventsSort = 'STARTS_AT_ASC'
+const eventsSort = 'STARTS_AT_DESC'
 
 const actionLinks = (event, deleteEvent) => (
   <div className={s.actionColumn}>

--- a/app/javascript/pages/admin/Events/queries/index.gql
+++ b/app/javascript/pages/admin/Events/queries/index.gql
@@ -1,5 +1,6 @@
 #import "fragments/EventEntry.gql"
 #import "fragments/OfficeEntry.gql"
+#import "fragments/UserEntry.gql"
 
 query EventsQuery($officeId: ID) {
   currentUser {

--- a/app/javascript/pages/admin/Events/queries/index.gql
+++ b/app/javascript/pages/admin/Events/queries/index.gql
@@ -2,12 +2,12 @@
 #import "fragments/OfficeEntry.gql"
 #import "fragments/UserEntry.gql"
 
-query EventsQuery($officeId: ID) {
+query EventsQuery($officeId: ID, $sortBy: EventSortEnum,) {
   currentUser {
     ...UserEntry
     isAdmin
   }
-  events(officeId: $officeId) {
+  events(officeId: $officeId, sortBy: $sortBy) {
     ...EventEntry
     office {
       ...OfficeEntry

--- a/test/graph/resolvers/event_resolver_test.rb
+++ b/test/graph/resolvers/event_resolver_test.rb
@@ -115,8 +115,8 @@ describe EventResolver do
       )
     end
     let(:event1_start) { Time.new(2018, 1, 1, 1, 0) }
-    let(:event2_start) { Time.new(2018, 1, 1, 3, 0) }
-    let(:event3_start) { Time.new(2018, 1, 1, 2, 0) }
+    let(:event2_start) { Time.new(2018, 1, 1, 2, 0) }
+    let(:event3_start) { Time.new(2018, 1, 1, 3, 0) }
     let(:current_user) { users(:admin) }
     let(:context) { { current_user: current_user } }
 
@@ -125,20 +125,20 @@ describe EventResolver do
 
     before {
       Event.delete_all
-      event1
       event2
+      event1
       event3
     }
 
     it 'returns all events' do
-      assert_equal [event1, event2, event3].map(&:title), all_events.pluck(:title)
+      assert_equal [event2, event1, event3].map(&:title), all_events.pluck(:title)
     end
 
     describe 'when sorting by descending' do
       let(:args) { { sortBy: 'STARTS_AT_DESC' } }
 
       it 'returns latest events first' do
-        assert_equal [event2, event3, event1].map(&:title), all_events.pluck(:title)
+        assert_equal [event3, event2, event1].map(&:title), all_events.pluck(:title)
       end
     end
 
@@ -146,7 +146,7 @@ describe EventResolver do
       let(:args) { { sortBy: 'STARTS_AT_ASC' } }
 
       it 'returns oldest events first' do
-        assert_equal [event1, event3, event2].map(&:title), all_events.pluck(:title)
+        assert_equal [event1, event2, event3].map(&:title), all_events.pluck(:title)
       end
     end
 
@@ -154,7 +154,7 @@ describe EventResolver do
       let(:args) { { officeId: 'all' } }
 
       it 'returns all events' do
-        assert_equal [event1, event2, event3].map(&:title), all_events.pluck(:title)
+        assert_equal [event2, event1, event3].map(&:title), all_events.pluck(:title)
       end
     end
 
@@ -162,7 +162,7 @@ describe EventResolver do
       let(:args) { { officeId: 'current' } }
 
       it 'returns some events' do
-        assert_equal [event1, event2].map(&:title), all_events.pluck(:title)
+        assert_equal [event2, event1].map(&:title), all_events.pluck(:title)
       end
     end
   end

--- a/test/graph/resolvers/event_resolver_test.rb
+++ b/test/graph/resolvers/event_resolver_test.rb
@@ -72,4 +72,79 @@ describe EventResolver do
       assert_nil Event.find_by(id: id)
     end
   end
+
+  describe '.all' do
+    let(:organization) { organizations(:minimum) }
+    let(:event_type) { event_types(:minimum) }
+    let(:office) { offices(:san_francisco) }
+    let(:event1) do
+      Event.create!(
+        organization: organization,
+        title: 'test1',
+        type: event_type,
+        starts_at: event1_start,
+        ends_at: event1_start + 1.hour,
+        capacity: 10,
+        location: 'somewhere',
+        office: office
+      )
+    end
+    let(:event2) do
+      Event.create!(
+        organization: organization,
+        title: 'test2',
+        type: event_type,
+        starts_at: event2_start,
+        ends_at: event3_start + 1.hour,
+        capacity: 10,
+        location: 'somewhere',
+        office: office
+      )
+    end
+    let(:event3) do
+      Event.create!(
+        organization: organization,
+        title: 'test3',
+        type: event_type,
+        starts_at: event3_start,
+        ends_at: event3_start + 1.hour,
+        capacity: 10,
+        location: 'somewhere',
+        office: office
+      )
+    end
+    let(:event1_start) { Time.new(2018, 1, 1, 1, 0) }
+    let(:event2_start) { Time.new(2018, 1, 1, 3, 0) }
+    let(:event3_start) { Time.new(2018, 1, 1, 2, 0) }
+
+    let(:args) { {} }
+    let(:all_events) { EventResolver.all(nil, args, nil) }
+
+    before {
+      Event.delete_all
+      event1
+      event2
+      event3
+    }
+
+    it 'returns all events' do
+      assert_equal [event1, event2, event3].map(&:title), all_events.pluck(:title)
+    end
+
+    describe 'when sorting by descending' do
+      let(:args) { { sortBy: 'STARTS_AT_DESC' } }
+
+      it 'returns latest events first' do
+        assert_equal [event2, event3, event1].map(&:title), all_events.pluck(:title)
+      end
+    end
+
+    describe 'when sorting by ascending' do
+      let(:args) { { sortBy: 'STARTS_AT_ASC' } }
+
+      it 'returns oldest events first' do
+        assert_equal [event1, event3, event2].map(&:title), all_events.pluck(:title)
+      end
+    end
+  end
 end

--- a/test/graph/resolvers/event_resolver_test.rb
+++ b/test/graph/resolvers/event_resolver_test.rb
@@ -77,6 +77,7 @@ describe EventResolver do
     let(:organization) { organizations(:minimum) }
     let(:event_type) { event_types(:minimum) }
     let(:office) { offices(:san_francisco) }
+    let(:other_office) { offices(:madison) }
     let(:event1) do
       Event.create!(
         organization: organization,
@@ -110,15 +111,17 @@ describe EventResolver do
         ends_at: event3_start + 1.hour,
         capacity: 10,
         location: 'somewhere',
-        office: office
+        office: other_office
       )
     end
     let(:event1_start) { Time.new(2018, 1, 1, 1, 0) }
     let(:event2_start) { Time.new(2018, 1, 1, 3, 0) }
     let(:event3_start) { Time.new(2018, 1, 1, 2, 0) }
+    let(:current_user) { users(:admin) }
+    let(:context) { { current_user: current_user } }
 
     let(:args) { {} }
-    let(:all_events) { EventResolver.all(nil, args, nil) }
+    let(:all_events) { EventResolver.all(nil, args, context) }
 
     before {
       Event.delete_all
@@ -144,6 +147,22 @@ describe EventResolver do
 
       it 'returns oldest events first' do
         assert_equal [event1, event3, event2].map(&:title), all_events.pluck(:title)
+      end
+    end
+
+    describe 'for all offices' do
+      let(:args) { { officeId: 'all' } }
+
+      it 'returns all events' do
+        assert_equal [event1, event2, event3].map(&:title), all_events.pluck(:title)
+      end
+    end
+
+    describe 'for your office' do
+      let(:args) { { officeId: 'current' } }
+
+      it 'returns some events' do
+        assert_equal [event1, event2].map(&:title), all_events.pluck(:title)
       end
     end
   end


### PR DESCRIPTION
Makes default sorting for the admin page listing events show the latest event first.
This is a first step, there is more that needs to be sorted.
To test it out navigate to `http://localhost:5000/portal/admin/events`
Newest events should be at the top

For https://github.com/zendesk/volunteer_portal/issues/49