### PR TITLE
Fix leaderboard query

### DIFF
--- a/app/graph/types/query_graph_type.rb
+++ b/app/graph/types/query_graph_type.rb
@@ -69,6 +69,8 @@ QueryGraphType = GraphQL::ObjectType.define do
 
     argument :officeId, types.ID
     argument :sortBy,   UserSortEnum
+    argument :after,    types.Int, 'earliest start time allowed'
+    argument :before,   types.Int, 'latest start time allowed'
     argument :count,    types.Int, 'The number of users to return after sorting if sortBy is given'
 
     resolve UserResolver.method(:all)

--- a/app/javascript/pages/Dashboard/leaderboardQuery.gql
+++ b/app/javascript/pages/Dashboard/leaderboardQuery.gql
@@ -2,7 +2,7 @@
 #import "fragments/OfficeEntry.gql"
 
 query LeaderboardQuery($count: Int, $sortBy: UserSortEnum, $officeId: ID, $after: Int, $before: Int) {
-  users(count: $count, sortBy: $sortBy, officeId: $officeId) {
+  users(count: $count, sortBy: $sortBy, officeId: $officeId, after: $after, before: $before) {
     ...UserEntry
     hours(after: $after, before: $before)
     office {


### PR DESCRIPTION
Fixes #53 

`LeaderboardQuery` was pulling the top 10 volunteers overall, while the dashboard displays hours for the [current year only](https://github.com/zendesk/volunteer_portal/blob/master/app/javascript/pages/Dashboard/index.js#L173-L174). This fixes it to make the leaderboard query pull the top 10 volunteers for the current year, so it's consistent with the number of hours displayed.