### PR TITLE
Add to Google Calendar

### DIFF
--- a/app/javascript/pages/Event/index.js
+++ b/app/javascript/pages/Event/index.js
@@ -33,6 +33,24 @@ const Section = ({ title, children }) => (
   </div>
 )
 
+const AddToGoogleCalendar = ({ event }) => {
+  const formatDateTime = R.replace(/-|:/g, '')
+  const { title, description, location, startsAt, endsAt, office: { timezone } } = event
+  const templateUrl =
+    'http://www.google.com/calendar/event?action=TEMPLATE' +
+    `&text=${title}` +
+    `&dates=${formatDateTime(startsAt)}/${formatDateTime(endsAt)}` +
+    `&ctz=${timezone}` +
+    `&details=${description}` +
+    `&location=${location}`
+
+  return (
+    <a href={templateUrl} target="_blank" rel="nofollow noreferrer">
+      Add to Google Calendar
+    </a>
+  )
+}
+
 // TODO: no local component state
 class MapPreview extends Component {
   constructor(props) {
@@ -145,8 +163,8 @@ const Event = ({ data: { loading, event, currentUser }, createSignup, destroySig
             </Section>
           </div>
           <div className={s.rightCol}>
-            <Section title="Information">
-              <div />
+            <Section title="Export">
+              <AddToGoogleCalendar event={event} />
             </Section>
           </div>
         </div>

--- a/app/javascript/pages/Event/index.js
+++ b/app/javascript/pages/Event/index.js
@@ -5,9 +5,6 @@ import R from 'ramda'
 import { Link } from 'react-router'
 import { GoogleMapLoader, GoogleMap, Marker } from 'react-google-maps'
 
-import LocationIcon from 'material-ui/svg-icons/maps/place'
-import ClockIcon from 'material-ui/svg-icons/action/schedule'
-
 import EventLocation from 'components/EventLocation'
 import EventTime from 'components/EventTime'
 import LabeledProgress from 'components/LabeledProgress'

--- a/app/javascript/pages/admin/Events/form.js
+++ b/app/javascript/pages/admin/Events/form.js
@@ -2,11 +2,8 @@ import React from 'react'
 import { reduxForm } from 'redux-form'
 import { connect } from 'react-redux'
 import R from 'ramda'
-import moment from 'moment-timezone'
 
 import EventForm from 'components/EventForm'
-
-import s from './form.css'
 
 const validate = values => {
   const errors = {}

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -5,7 +5,6 @@ import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
-import { filterByOffice } from 'lib/utils'
 import moment from 'moment'
 
 import { graphQLError } from 'actions'


### PR DESCRIPTION
@zendesk/volunteer-eng 

Addresses #59. 

* Adds a "Add to Google Calendar" link to event page. The link opens a pre-filled Google Calendar event form.
* Removes unused imports.

![](https://cl.ly/55c3f78bf155/Screen%20Recording%202018-08-29%20at%2003.15%20pm.gif)