### PR TITLE
Organization address autocomplete

### DIFF
--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -1,14 +1,11 @@
 import React from 'react'
 import { Field } from 'redux-form'
-import moment from 'moment-timezone'
 import R from 'ramda'
-import Geosuggest from 'react-geosuggest'
 import AutoComplete from 'material-ui/AutoComplete'
 import DatePicker from 'material-ui/DatePicker'
 import TimePicker from 'material-ui/TimePicker'
 
 import Callout from 'components/Callout'
-import Loading from 'components/LoadingIcon'
 
 import s from './main.css'
 

--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -6,6 +6,7 @@ import DatePicker from 'material-ui/DatePicker'
 import TimePicker from 'material-ui/TimePicker'
 
 import Callout from 'components/Callout'
+import LocationField from 'components/LocationField'
 
 import s from './main.css'
 
@@ -105,16 +106,6 @@ const OrganizationField = ({ organizations, input: { value, onChange } }) => (
     className={s.muiTextField}
     textFieldStyle={styles.muiTextField}
     fullWidth
-  />
-)
-
-const LocationField = ({ input: { value, onChange } }) => (
-  <Geosuggest
-    inputClassName={s.field}
-    suggestsClassName={s.autocompleteList}
-    initialValue={value}
-    onChange={onChange}
-    onSuggestSelect={s => onChange(s.gmaps.formatted_address)}
   />
 )
 

--- a/app/javascript/components/EventForm/main.css
+++ b/app/javascript/components/EventForm/main.css
@@ -88,13 +88,6 @@ select.field {
   color: #fff;
 }
 
-.autocompleteList {
-  list-style: none;
-  color: #555;
-  padding-left: 10px;
-  margin: 0;
-}
-
 .muiTextField hr {
   display: none;
 }

--- a/app/javascript/components/LocationField/index.js
+++ b/app/javascript/components/LocationField/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import Geosuggest from 'react-geosuggest'
+
+import s from './main.css'
+
+const LocationField = ({ input: { value, onChange } }) => (
+  <Geosuggest
+    autoComplete="off"
+    inputClassName={s.field}
+    suggestsClassName={s.autocompleteList}
+    initialValue={value}
+    onChange={onChange}
+    onSuggestSelect={s => onChange(s.gmaps.formatted_address)}
+  />
+)
+
+export default LocationField

--- a/app/javascript/components/LocationField/main.css
+++ b/app/javascript/components/LocationField/main.css
@@ -1,0 +1,16 @@
+.field {
+  border: 1px solid #ddd;
+  padding: 5px;
+  border-radius: 5px;
+  min-width: 300px;
+  font-size: 12pt;
+  background: none;
+  width: calc(100% - 10px); /* 100% - left and right padding */
+}
+
+.autocompleteList {
+  list-style: none;
+  color: #555;
+  padding-left: 10px;
+  margin: 0;
+}

--- a/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
+++ b/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
@@ -81,17 +81,35 @@ exports[`loads 1`] = `
         </span>
       </label>
       <div>
-        <input
-          className="field"
-          name="location"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onDragStart={[Function]}
-          onDrop={[Function]}
-          onFocus={[Function]}
-          type="text"
-          value=""
-        />
+        <div
+          className="geosuggest"
+        >
+          <div
+            className="geosuggest__input-wrapper"
+          >
+            <input
+              autoComplete="off"
+              className="geosuggest__input field"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              placeholder="Search places"
+              style={Object {}}
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="geosuggest__suggests-wrapper"
+          >
+            <ul
+              className="geosuggest__suggests autocompleteList geosuggest__suggests--hidden"
+              style={Object {}}
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/components/OrganizationForm/index.js
+++ b/app/javascript/components/OrganizationForm/index.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { Field } from 'redux-form'
-import moment from 'moment-timezone'
 import R from 'ramda'
-import AutoComplete from 'material-ui/AutoComplete'
 
 import Callout from 'components/Callout'
 

--- a/app/javascript/components/OrganizationForm/index.js
+++ b/app/javascript/components/OrganizationForm/index.js
@@ -3,6 +3,7 @@ import { Field } from 'redux-form'
 import R from 'ramda'
 
 import Callout from 'components/Callout'
+import LocationField from 'components/LocationField'
 
 import s from './main.css'
 
@@ -60,7 +61,14 @@ const OrganizationForm = ({ handleSubmit, disableSubmit, errors }) => (
       <Field label="Description" className={s.field} name="description" component={renderField} type="text" />
     </div>
     <div className={s.inputGroup}>
-      <Field label="Location" className={s.field} name="location" component={renderField} type="text" />
+      <Field
+        label="Location"
+        className={s.field}
+        name="location"
+        component={renderField}
+        Custom={LocationField}
+        type="text"
+      />
     </div>
     <div className={s.inputGroup}>
       <Field label="Website" className={s.field} name="website" component={renderField} type="text" />


### PR DESCRIPTION
@zendesk/volunteer-eng 

Address #4. Autocomplete address field in organization form.

* Extract `LocationField` out of `components/EventForm/index` to `lib/fields`
* Use `LocationField` in `OrganizationForm/index`
* Refactor unused imports

For future improvements, `DateField` can be extract out to `lib/fields` to avoid code duplication.