### PR TITLE
Use year in event date format

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -49,13 +49,13 @@ const columns = deleteEvent => [
     Header: 'Start',
     accessor: 'startsAt',
     sortable: false,
-    Cell: ({ value }) => moment(value).format('MMM D, h:mm a'),
+    Cell: ({ value }) => moment(value).format('h:mm a, MMM D, Y'),
   },
   {
     Header: 'End',
     accessor: 'endsAt',
     sortable: false,
-    Cell: ({ value }) => moment(value).format('MMM D, h:mm a'),
+    Cell: ({ value }) => moment(value).format('h:mm a, MMM D, Y'),
   },
   {
     Header: 'Actions',


### PR DESCRIPTION
With a substantial amount of events, it's annoying to have to click into a random event to find out which year that date is from.  So the page now displays the year as well.
Not sure about date format, went with `h:mm a, MMM D, Y` but open to suggestions