### PR TITLE
Sort by hours on the client

### DIFF
--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -117,6 +117,8 @@ const milestoneLabelStyling = (item, milestone, user) => {
   return R.join(' ', classes)
 }
 
+const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users)
+
 const LeaderboardContainer = ({
   data: { networkStatus, users, offices, currentUser },
   dashboardOfficeFilter,
@@ -135,7 +137,7 @@ const LeaderboardContainer = ({
           itemValueProp="name"
         />
       </div>
-      {users.map((user, i) => (
+      {sortByHours(users).map((user, i) => (
         <div className={s.leaderboardUser} key={`user-${i}`}>
           <NamedAvatar image={user.photo} name={user.name} subtitle={user.group} />
           <span className={s.leaderboardHours}>{user.hours} hours</span>


### PR DESCRIPTION
It seems like the server is not sorting the leaderboard by hours correctly when including individual events. I'm [reinstating sorting in the client](https://github.com/zendesk/volunteer_portal/pull/62/commits/52d2ca1a1e592b0b20076bb3cb60b2caadd6edc4#r213571900) for now.

cc @zendesk/volunteer 