### PR TITLE
Modify cancel button color on Create Event form

### DIFF
--- a/app/javascript/pages/IndividualEvents/main.css
+++ b/app/javascript/pages/IndividualEvents/main.css
@@ -52,7 +52,7 @@
 }
 
 .cancelBtn {
-  color: #aaa;
+  color: #ff542e;
 }
 
 .confirmBtn {

--- a/app/javascript/pages/admin/IndividualEvents/main.css
+++ b/app/javascript/pages/admin/IndividualEvents/main.css
@@ -93,7 +93,7 @@ select.input {
 }
 
 .cancelBtn {
-  color: #aaa;
+  color: #ff542e;
 }
 
 .confirmBtn {


### PR DESCRIPTION
We modified the color of the Cancel Button on Create and Edit Individual Event Page, according to Issue #68. For consistency, we went with the color of * Required (same row - far left).

<details>
<summary>Before</summary>
<img width="757" alt="before" src="https://user-images.githubusercontent.com/17760485/46711149-d5448b80-cc96-11e8-95de-7576db54a587.png">
</details>

<details>
<summary>After</summary>
<img width="766" alt="after" src="https://user-images.githubusercontent.com/17760485/46711174-e7262e80-cc96-11e8-8495-96064d5adf99.png">
</details>