### PR TITLE
Change organisation description text input to textarea

### DIFF
--- a/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
+++ b/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
@@ -51,15 +51,15 @@ exports[`loads 1`] = `
         </span>
       </label>
       <div>
-        <input
-          className="field"
+        <textarea
+          className="textfield"
           name="description"
           onBlur={[Function]}
           onChange={[Function]}
           onDragStart={[Function]}
           onDrop={[Function]}
           onFocus={[Function]}
-          type="text"
+          type="textarea"
           value=""
         />
       </div>

--- a/app/javascript/components/OrganizationForm/index.js
+++ b/app/javascript/components/OrganizationForm/index.js
@@ -25,6 +25,8 @@ const renderFieldHelper = ({ input, type, label, className, selectOptions }) => 
     case 'input':
     case 'text':
       return <input {...input} type={type} className={className} />
+    case 'textarea':
+      return <textarea {...input} type={type} className={className} />
     case 'select':
       return (
         <select {...input} className={className}>
@@ -58,7 +60,7 @@ const OrganizationForm = ({ handleSubmit, disableSubmit, errors }) => (
       <Field label="Name" className={s.field} name="name" component={renderField} type="text" />
     </div>
     <div className={s.inputGroup}>
-      <Field label="Description" className={s.field} name="description" component={renderField} type="text" />
+      <Field label="Description" className={s.textfield} name="description" component={renderField} type="textarea" />
     </div>
     <div className={s.inputGroup}>
       <Field

--- a/app/javascript/components/OrganizationForm/main.css
+++ b/app/javascript/components/OrganizationForm/main.css
@@ -20,7 +20,17 @@
   border: 1px solid #ddd;
   padding: 5px;
   border-radius: 5px;
-  min-width: 300px;
+  min-width: 500px;
+  font-size: 12pt;
+  background: none;
+}
+
+.textfield {
+  height: 100px;
+  width: 500px;
+  border: 1px solid #ddd;
+  padding: 5px;
+  border-radius: 5px;
   font-size: 12pt;
   background: none;
 }


### PR DESCRIPTION
This is in reference to Issue #76. Currently, the organisation description text box uses the text field and is of limited size. This change will modify the type and size of the description text input to textarea to accommodate more room for text.

<details><summary>Before</summary>
<img width="664" alt="screen shot 2018-10-10 at 4 50 12 pm" src="https://user-images.githubusercontent.com/37169084/46715774-2790a700-ccad-11e8-9d9e-48cd3b848e98.png">
</details>

<details><summary>After</summary>
<img width="806" alt="screen shot 2018-10-10 at 4 39 22 pm" src="https://user-images.githubusercontent.com/37169084/46715798-42fbb200-ccad-11e8-8d95-6a831dc71ffe.png">
</details>