### PR TITLE
add ./script/setup_db.sh

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -30,12 +30,6 @@
 
    The easiest thing is probably to use their app. http://postgresapp.com/
 
-1. Create the `volunteer` database role
-
-   ```bash
-   psql -c 'CREATE ROLE volunteer WITH LOGIN SUPERUSER'
-   ```
-
 1. Copy the `.env.development.example` file to `.env.development`
 
    ```bash
@@ -93,12 +87,11 @@ guide you through the process.
 
 Make sure that PostgreSQL is running.
 
-Create the database by running the command line below. You should only need to do this once.
+1. Create and set up your database (you should only need to do this once):
 
- ```
- ./bin/rails db:setup
- ```
-
+   ```bash
+   ./script/setup_db.sh
+   ```
 
 To start the app and run it locally, run the command line blow. `foreman` is used to run both the rails server and the webpack dev server in development.
 

--- a/script/setup_db.sh
+++ b/script/setup_db.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+psql -d postgres -c 'CREATE ROLE volunteer WITH LOGIN SUPERUSER'
+bundle exec ./bin/rails db:setup


### PR DESCRIPTION
Short description

add ./script/setup_db.sh, which combines the create user & rails db setup.

It also specifies `-d postgres`, because on a plain postgres setup after `initdb`, there is only a `postgres` database:

> The first database is always created by the initdb command when the data storage area is initialized. (See Section 17.2.) This database is called postgres. So to create the first "ordinary" database you can connect to postgres.

(https://www.postgresql.org/docs/9.2/static/manage-ag-createdb.html)

/cc @zendesk/volunteer 
