### PR TITLE
added missing dependency `moment`

### DIFF
--- a/app/javascript/pages/admin/Events/form.js
+++ b/app/javascript/pages/admin/Events/form.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import R from 'ramda'
 
 import EventForm from 'components/EventForm'
+import moment from 'moment'
 
 const validate = values => {
   const errors = {}


### PR DESCRIPTION
Creating new event fails to load due to missing dependency. Adding dependency fixes the error.
@zendesk/volunteer
@liulikun 