### PR TITLE
Hide nav bar on reporting page

### DIFF
--- a/app/javascript/components/EventTypeForm/__snapshots__/test.js.snap
+++ b/app/javascript/components/EventTypeForm/__snapshots__/test.js.snap
@@ -40,7 +40,7 @@ exports[`loads 1`] = `
   >
     <button
       className="btn primary"
-      disabled={undefined}
+      disabled={false}
       type="submit"
     >
       Save

--- a/app/javascript/components/EventTypeForm/test.js
+++ b/app/javascript/components/EventTypeForm/test.js
@@ -15,7 +15,7 @@ const handleSubmit = () => {}
 test('loads', () => {
   const component = renderer.create(
     <Provider store={store}>
-      <WithReduxForm handleSubmit={handleSubmit} disableSumbit={false} />
+      <WithReduxForm handleSubmit={handleSubmit} disableSubmit={false} />
     </Provider>
   )
   const tree = component.toJSON()

--- a/app/javascript/pages/Calendar/index.js
+++ b/app/javascript/pages/Calendar/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { compose, graphql } from 'react-apollo'
 import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
-import { navigate } from 'react-big-calendar/lib/utils/constants'
 import R from 'ramda'
 import moment from 'moment'
 

--- a/app/javascript/pages/admin/Reporting/index.js
+++ b/app/javascript/pages/admin/Reporting/index.js
@@ -10,8 +10,7 @@ import Reporting from 'components/Reporting'
 import { changeAdminReportingStart, changeAdminReportingEnd } from 'actions'
 
 import ReportingQuery from './query.gql'
-
-import adminStyle from './../Admin/main.css'
+import s from './main.css'
 
 const defaultStartDate = moment().startOf('year')
 const defaultEndDate = moment().endOf('year')
@@ -29,8 +28,8 @@ const ReportingPage = ({
   networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
-    <div className={adminStyle.admin}>
-      <div className={adminStyle.content}>
+    <div className={s.admin}>
+      <div className={s.content}>
         <Reporting
           users={users}
           startDate={reportingStartDate}

--- a/app/javascript/pages/admin/Reporting/index.js
+++ b/app/javascript/pages/admin/Reporting/index.js
@@ -11,6 +11,8 @@ import { changeAdminReportingStart, changeAdminReportingEnd } from 'actions'
 
 import ReportingQuery from './query.gql'
 
+import adminStyle from './../Admin/main.css'
+
 const defaultStartDate = moment().startOf('year')
 const defaultEndDate = moment().endOf('year')
 
@@ -27,13 +29,17 @@ const ReportingPage = ({
   networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
-    <Reporting
-      users={users}
-      startDate={reportingStartDate}
-      endDate={reportingEndDate}
-      onStartChange={changeAdminReportingStart}
-      onEndChange={changeAdminReportingEnd}
-    />
+    <div className={adminStyle.admin}>
+      <div className={adminStyle.content}>
+        <Reporting
+          users={users}
+          startDate={reportingStartDate}
+          endDate={reportingEndDate}
+          onStartChange={changeAdminReportingStart}
+          onEndChange={changeAdminReportingEnd}
+        />
+      </div>
+    </div>
   )
 
 const mapStateToProps = ({ model: { adminOfficeFilter, reportingStartDate, reportingEndDate } }) => ({

--- a/app/javascript/pages/admin/Reporting/main.css
+++ b/app/javascript/pages/admin/Reporting/main.css
@@ -1,0 +1,9 @@
+.admin {
+  display: flex;
+  justify-content: space-around;
+  padding-bottom: 50px;
+}
+
+.content {
+  width: 935px;
+}

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -29,6 +29,7 @@ export default (
   <div>
     <Route path="/portal" component={App}>
       {/* Admin Namespace */}
+      <Route path="/portal/admin/reporting" component={Reporting} />
       <Route path="/portal/admin" component={Admin}>
         <IndexRoute component={AdminDashboard} />
         <Route path="/portal/admin/events/new" component={NewEvent} />
@@ -46,7 +47,6 @@ export default (
         <Route path="/portal/admin/individual_events" component={IndividualEventsAdmin} />
         <Route path="/portal/admin/users/:id/edit" component={EditUser} />
         <Route path="/portal/admin/users" component={UsersAdmin} />
-        <Route path="/portal/admin/reporting" component={Reporting} />
         <Route path="*" component={AdminDashboard} />
       </Route>
       {/* Default Namespace */}


### PR DESCRIPTION
@zendesk/volunteer

## Description
Fix #73. Hide nav bar on reporting page.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/73)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://cl.ly/1f4f20b046c8/Image%202018-10-24%20at%204.01.24%20pm.png">
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/181c856b0c95/Image%202018-10-24%20at%204.01.01%20pm.png">
</details>

## Risks (if any)
* low - reporting page is not properly rendered
