### PR TITLE
Remove timezone from Users and Organizations page

### DIFF
--- a/app/javascript/fragments/UserEntry.gql
+++ b/app/javascript/fragments/UserEntry.gql
@@ -3,4 +3,5 @@ fragment UserEntry on User {
   name
   email
   photo
+  isAdmin
 }

--- a/app/javascript/pages/admin/Organizations/index.js
+++ b/app/javascript/pages/admin/Organizations/index.js
@@ -27,14 +27,37 @@ const actionLinks = (organization, togglePopover) => (
   </div>
 )
 
+const websiteLink = ({ original: organization }) => {
+  let websiteUrl = organization.website
+  if (!/^https?:\/\//i.test(websiteUrl)) {
+    websiteUrl = 'http://' + websiteUrl
+  }
+
+  return <a href={websiteUrl}>{organization.website}</a>
+}
+
+const descriptionWithTitleText = ({ original: organization }) => {
+  return <div title={organization.description}>{organization.description}</div>
+}
+
 const columns = togglePopover => [
   {
     Header: 'Name',
     accessor: 'name',
   },
   {
-    Header: 'Timezone',
-    accessor: 'timezone',
+    Header: 'Description',
+    accessor: 'description',
+    Cell: descriptionWithTitleText,
+  },
+  {
+    Header: 'Website',
+    accessor: 'website',
+    Cell: websiteLink,
+  },
+  {
+    Header: 'Location',
+    accessor: 'location',
     sortable: false,
   },
   {

--- a/app/javascript/pages/admin/Users/index.js
+++ b/app/javascript/pages/admin/Users/index.js
@@ -6,6 +6,7 @@ import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
 import Dialog from 'material-ui/Dialog'
+import NavigationCheck from 'material-ui/svg-icons/navigation/check'
 
 import { graphQLError, togglePopover } from 'actions'
 
@@ -27,15 +28,29 @@ const actionLinks = (user, togglePopover) => (
   </div>
 )
 
+const adminIconDimension = {
+  height: 18,
+  width: 18,
+}
+
+const showAdminIcon = user => (user.isAdmin ? <NavigationCheck style={adminIconDimension} /> : <div />)
+
 const columns = togglePopover => [
   {
     Header: 'Name',
     accessor: 'name',
   },
   {
-    Header: 'Timezone',
-    accessor: 'timezone',
-    sortable: false,
+    Header: 'Email',
+    accessor: 'email',
+    sortable: true,
+  },
+  {
+    Header: 'Admin',
+    accessor: 'isAdmin',
+    width: 130,
+    sortable: true,
+    Cell: ({ original }) => showAdminIcon(original),
   },
   {
     Header: 'Actions',
@@ -121,6 +136,7 @@ const Users = ({ data: { networkStatus, users }, deleteUser, togglePopover, dest
         data={users}
         columns={columns(togglePopover)}
         showPagination={false}
+        resizable={false}
         defaultPageSize={users.length}
         minRows={0}
         defaultFilterMethod={filterMethod}


### PR DESCRIPTION
## Description
The Users and the Organizations tables in the admin pages have Timezone column, but data for them don't have that field. This PR removes the Timezone column.

Additionally, this PR adds Description, Website and Location columns to Organizations table. It also adds Email and Admin columns to the Users Table

## References
Fixes [organisation & users section have time zone header](https://github.com/zendesk/volunteer_portal/issues/77)

## Screenshots (if needed)
**Before:**
![image](https://user-images.githubusercontent.com/1055079/48694463-54729b00-ec17-11e8-97f5-f994d110d021.png)
**After:**
![image](https://user-images.githubusercontent.com/1055079/48694525-808e1c00-ec17-11e8-9cc1-7c1afb6f7506.png)

## CCs
@blakegong @rshokrizadeh @shiyunl 

## Risks (if any)
* [low] - Users and Organizations Admin View could be broken
