### PR TITLE
Display office name under name of user

### DIFF
--- a/app/javascript/components/Header/index.js
+++ b/app/javascript/components/Header/index.js
@@ -57,7 +57,10 @@ const Header = ({ currentUser, offices, togglePopover, popover, handleOfficeSele
           <div>
             <button className={s.btn} onClick={togglePopover}>
               <img className={s.img} src={currentUser.photo} />
-              <span className={s.userName}>{currentUser.name}</span>
+              <div className={s.userInfoBox}>
+                <div className={s.userName}>{currentUser.name}</div>
+                <div className={s.userOffice}>{currentUser.office && currentUser.office.name}</div>
+              </div>
               <Popover
                 className={s.popover}
                 open={present(popover)}

--- a/app/javascript/components/Header/main.css
+++ b/app/javascript/components/Header/main.css
@@ -38,25 +38,31 @@
 }
 
 .btn {
-  height: 40px;
-  line-height: 40px;
   background: none;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  padding: 7px;
+  border: none;
 }
 
 .img {
-  height: 25px;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+  float: left;
+  vertical-align: middle;
   margin-right: 10px;
+}
+
+.userInfoBox {
   display: inline-block;
+  line-height: 16px;
+  text-align: left;
 }
 
 .userName {
-  display: inline-block;
-  height: 25px;
-  line-height: 25px;
-  float: right;
+  line-height: 16px;
+}
+
+.userOffice {
+  color: #555;
 }
 
 .item {


### PR DESCRIPTION
## Description

Seems from #66, #67, letting users know of their current office more promptly is an issue. We worked with our designer @shiyunl to come up with some small tweaks to make that more obvious.

## Screenshots

1. Normal
    <img width="1253" alt="screenshot 2018-11-19 at 4 29 47 pm" src="https://user-images.githubusercontent.com/3624869/48695432-1460e780-ec1a-11e8-802c-80b57f72ca9e.png">

1. With long office name
    <img width="1253" alt="screenshot 2018-11-19 at 4 30 03 pm" src="https://user-images.githubusercontent.com/3624869/48695474-32c6e300-ec1a-11e8-9abb-7365526c3cc1.png">

1. With long user name
    <img width="1253" alt="screenshot 2018-11-19 at 4 30 29 pm" src="https://user-images.githubusercontent.com/3624869/48695486-39edf100-ec1a-11e8-983c-585653690202.png">

1. Normal user mode
    <img width="1253" alt="screenshot 2018-11-19 at 4 31 30 pm" src="https://user-images.githubusercontent.com/3624869/48695501-3fe3d200-ec1a-11e8-980d-4541d0795e01.png">

## CCs

@rshokrizadeh @dineshsaravanan 

## Risks
Low, pure UI change.
