### PR TITLE
Allow admin to remove user from event

### DIFF
--- a/app/graph/types/mutation_graph_type.rb
+++ b/app/graph/types/mutation_graph_type.rb
@@ -20,8 +20,10 @@ MutationGraphType = GraphQL::ObjectType.define do
     argument :eventId, !types.ID
     argument :userId,  !types.ID
 
-    resolve -> (_, args, _) do
-      signup = Signup.find_by!(event_id: args[:eventId], user_id: args[:userId])
+    resolve -> (_, args, context) do
+      user = context[:current_user]
+      scope = user.role == Role.admin ? Signup : user.signups
+      signup = scope.find_by!(event_id: args[:eventId], user_id: args[:userId])
       signup.event.remove_user!(signup.user)
       signup
     end

--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -6,6 +6,7 @@ import DatePicker from 'material-ui/DatePicker'
 import TimePicker from 'material-ui/TimePicker'
 
 import Callout from 'components/Callout'
+import UserList from 'components/UserList'
 import LocationField from 'components/LocationField'
 
 import s from './main.css'
@@ -133,7 +134,16 @@ const TimeField = ({ input: { value, onChange } }) => (
   />
 )
 
-const EventForm = ({ handleSubmit, disableSubmit, errors, eventTypes, organizations, offices }) => (
+const EventForm = ({
+  handleSubmit,
+  disableSubmit,
+  errors,
+  eventTypes,
+  organizations,
+  offices,
+  users,
+  destroySignup,
+}) => (
   <form className={s.form} onSubmit={handleSubmit}>
     {isNoErrors(errors) ? null : <Callout type="error" message={formatGraphQLErrors(errors)} />}
     <div className={s.inputGroup}>
@@ -218,6 +228,7 @@ const EventForm = ({ handleSubmit, disableSubmit, errors, eventTypes, organizati
         Save
       </button>
     </div>
+    <UserList users={users} destroySignup={destroySignup} />
   </form>
 )
 

--- a/app/javascript/components/Header/index.js
+++ b/app/javascript/components/Header/index.js
@@ -10,6 +10,7 @@ import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right'
 import ContentIcon from 'material-ui/svg-icons/content/create'
 import ReportingIcon from 'material-ui/svg-icons/av/equalizer'
 
+import { present } from '../../lib/utils'
 import s from './main.css'
 
 const styles = {
@@ -62,7 +63,7 @@ const Header = ({ currentUser, offices, togglePopover, popover, handleOfficeSele
               </div>
               <Popover
                 className={s.popover}
-                open={!!popover}
+                open={present(popover)}
                 anchorEl={popover ? popover.anchorEl : null}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                 targetOrigin={{ horizontal: 'right', vertical: 'top' }}

--- a/app/javascript/components/NamedAvatar.js
+++ b/app/javascript/components/NamedAvatar.js
@@ -1,5 +1,9 @@
 import React from 'react'
 import Avatar from './Avatar'
+import Dialog from 'material-ui/Dialog'
+import { connect } from 'react-redux'
+import { togglePopover } from 'actions'
+import { present } from '../lib/utils'
 
 const styles = {
   container: {
@@ -16,17 +20,71 @@ const styles = {
   name: {
     fontWeight: 600,
   },
-  subtitle: {},
+  remove: {
+    marginLeft: 20,
+    cursor: 'pointer',
+  },
+  dialogActionsLink: {
+    padding: 15,
+    cursor: 'pointer',
+    fontSize: 16,
+  },
+  actionsContainer: {
+    paddingBottom: 20,
+    textAlign: 'center',
+  },
 }
 
-const NamedAvatar = props => (
+const dialogActions = (togglePopover, onRemove) => [
+  <a style={styles.dialogActionsLink} onClick={() => togglePopover('removeUserFromEvent')}>
+    Cancel
+  </a>,
+  <a
+    style={styles.dialogActionsLink}
+    onClick={() => {
+      onRemove()
+      togglePopover('removeUserFromEvent')
+    }}
+  >
+    Delete
+  </a>,
+]
+
+const NamedAvatar = ({ userId, image, name, subtitle, showRemove, onRemove, togglePopover, popover }) => (
   <div style={styles.container}>
-    <Avatar {...props} />
+    <Avatar image={image} />
     <div style={styles.details}>
-      <span style={styles.name}>{props.name}</span>
-      <span style={styles.subtitle}>{props.subtitle || '\u00a0'}</span>
+      <span style={styles.name}>{name}</span>
+      <span style={styles.subtitle}>{subtitle || '\u00a0'}</span>
     </div>
+    {showRemove && (
+      <a style={styles.remove} onClick={() => togglePopover('removeUserFromEvent', { userId })}>
+        Remove
+      </a>
+    )}
+    {present(popover) &&
+      popover.data.userId === userId && (
+        <Dialog
+          title={`Remove ${name} from Event`}
+          actions={dialogActions(togglePopover, onRemove)}
+          open
+          onRequestClose={() => togglePopover('removeUserFromEvent')}
+          actionsContainerStyle={styles.actionsContainer}
+        />
+      )}
   </div>
 )
 
-export default NamedAvatar
+const mapStateToProps = (state, { children }) => {
+  const { popover } = state.model
+
+  return {
+    popover,
+  }
+}
+
+const withActions = connect(mapStateToProps, {
+  togglePopover,
+})
+
+export default withActions(NamedAvatar)

--- a/app/javascript/components/SignupButton/index.js
+++ b/app/javascript/components/SignupButton/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import R from 'ramda'
 
+import { present } from '../../lib/utils'
 import s from './main.css'
 
 const SignupButton = ({ currentUser, event, createSignupHandler, destroySignupHandler }) => {
@@ -8,7 +9,7 @@ const SignupButton = ({ currentUser, event, createSignupHandler, destroySignupHa
     return <button disabled className={`${s.btn} ${s.primary}`} />
   }
 
-  const isRegistered = !!R.find(user => user.id === currentUser.id)(event.users)
+  const isRegistered = present(R.find(user => user.id === currentUser.id)(event.users))
   const isFull = event.users.length >= event.capacity
 
   let classNames = [s.btn, s.primary]

--- a/app/javascript/components/UserList/index.js
+++ b/app/javascript/components/UserList/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import NamedAvatar from 'components/NamedAvatar'
+
+import { present } from '../../lib/utils'
+import s from './main.css'
+
+const UserList = ({ users, destroySignup }) => (
+  <div className={s.avatarGrid}>
+    {users &&
+      users.map((user, i) => (
+        <div key={i} className={s.item}>
+          <NamedAvatar
+            userId={user.id}
+            image={user.photo}
+            name={user.name}
+            subtitle={user.group}
+            showRemove={present(destroySignup)}
+            onRemove={() => destroySignup(user)}
+          />
+        </div>
+      ))}
+  </div>
+)
+
+export default UserList

--- a/app/javascript/components/UserList/main.css
+++ b/app/javascript/components/UserList/main.css
@@ -1,0 +1,12 @@
+.avatarGrid {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+
+.item {
+  padding-right: 10px;
+  padding-bottom: 10px;
+  flex-basis: calc(50% - 10px);
+}

--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -35,7 +35,7 @@ const leaderBoardSort = 'HOURS_DESC'
 
 const selectMilestone = hours => R.find(m => hours < m.hours)(milestones) || R.last(milestones)
 
-const milestonePercentage = (user, milestone) => R.clamp(0, 100, Math.round((user.hours / milestone.hours) * 100))
+const milestonePercentage = (user, milestone) => R.clamp(0, 100, Math.round(user.hours / milestone.hours * 100))
 
 const hoursRemaining = (user, milestone) => {
   const computed = Math.round(milestone.hours - user.hours)
@@ -57,7 +57,7 @@ const barStyling = (segment, user, milestone) => {
 
   const inProgessWidth =
     completedMilestoneCount < milestones.length
-      ? R.clamp(0, milestoneBarWidth, (milestonePercentage(user, milestone) / 100) * milestoneBarChunk)
+      ? R.clamp(0, milestoneBarWidth, milestonePercentage(user, milestone) / 100 * milestoneBarChunk)
       : 0
 
   const incompleteWidth = R.clamp(0, milestoneBarWidth, milestoneBarWidth - inProgessWidth - completedWidth)
@@ -173,10 +173,7 @@ const leaderboardWithData = graphql(LeaderboardQuery, {
     }
   },
 })
-const leaderboardWithActions = connect(
-  mapStateToProps,
-  { changeDashboardOfficeFilter }
-)
+const leaderboardWithActions = connect(mapStateToProps, { changeDashboardOfficeFilter })
 const Leaderboard = leaderboardWithActions(leaderboardWithData(LeaderboardContainer))
 
 const Dashboard = ({ data: { networkStatus, currentUser }, locationBeforeTransitions }) => {
@@ -218,7 +215,7 @@ const Dashboard = ({ data: { networkStatus, currentUser }, locationBeforeTransit
                   <div
                     key={`milestone-${i}`}
                     className={s.milestoneMarker}
-                    style={{ flexBasis: `${(1 / milestones.length) * 100}%` }}
+                    style={{ flexBasis: `${1 / milestones.length * 100}%` }}
                   >
                     <p className={milestoneLabelStyling('label', activeMilestone, currentUser)}>{`Milestone ${
                       milestone.name

--- a/app/javascript/pages/Event/index.js
+++ b/app/javascript/pages/Event/index.js
@@ -10,8 +10,8 @@ import EventTime from 'components/EventTime'
 import LabeledProgress from 'components/LabeledProgress'
 import Layout from 'components/Layout'
 import Loading from 'components/LoadingIcon'
-import NamedAvatar from 'components/NamedAvatar'
 import SignupButton from 'components/SignupButton'
+import UserList from 'components/UserList'
 
 import EventQuery from './query.gql'
 import CreateSignupMutation from 'mutations/CreateSignupMutation.gql'
@@ -153,13 +153,7 @@ const Event = ({ data: { loading, event, currentUser }, createSignup, destroySig
                   />
                 </div>
               </div>
-              <div className={s.avatarGrid}>
-                {event.users.map((user, i) => (
-                  <div key={i} className={s.item}>
-                    <NamedAvatar image={user.photo} name={user.name} subtitle={user.group} />
-                  </div>
-                ))}
-              </div>
+              <UserList users={event.users} />
             </Section>
           </div>
           <div className={s.rightCol}>

--- a/app/javascript/pages/Event/main.css
+++ b/app/javascript/pages/Event/main.css
@@ -134,19 +134,3 @@
   margin-bottom: 20px;
   border-bottom: 1px solid #ddd;
 }
-
-
-/* AvatarGrid */
-.avatarGrid {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-content: flex-start;
-}
-
-.item {
-  padding-right: 10px;
-  padding-bottom: 10px;
-  flex-basis: calc(50% - 10px);
-}
-

--- a/app/javascript/pages/admin/Admin/index.js
+++ b/app/javascript/pages/admin/Admin/index.js
@@ -87,10 +87,7 @@ const OfficeFilter = ({ adminOfficeFilter, changeAdminOfficeFilter, offices }) =
 
 class Admin extends Component {
   componentDidUpdate() {
-    const {
-      history,
-      data: { networkStatus, currentUser },
-    } = this.props
+    const { history, data: { networkStatus, currentUser } } = this.props
 
     if (networkStatus !== NetworkStatus.loading && !currentUser.isAdmin) {
       history.push('/portal')
@@ -98,13 +95,7 @@ class Admin extends Component {
   }
 
   render() {
-    const {
-      routing,
-      children,
-      adminOfficeFilter,
-      changeAdminOfficeFilter,
-      data: { currentUser, offices },
-    } = this.props
+    const { routing, children, adminOfficeFilter, changeAdminOfficeFilter, data: { currentUser, offices } } = this.props
 
     if (adminOfficeFilter.value === 'current') {
       adminOfficeFilter.value = currentUser.office.id
@@ -167,11 +158,8 @@ const withData = graphql(AdminQuery, {
   },
 })
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    changeAdminOfficeFilter,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  changeAdminOfficeFilter,
+})
 
 export default withActions(withData(Admin))

--- a/app/javascript/pages/admin/Events/edit.js
+++ b/app/javascript/pages/admin/Events/edit.js
@@ -11,8 +11,14 @@ import Loading from 'components/LoadingIcon'
 
 import EventQuery from './queries/show.gql'
 import UpdateEventMutation from './mutations/update.gql'
+import DestroySignupMutation from 'mutations/DestroySignupMutation.gql'
 
-const EditEvent = ({ data: { networkStatus, event, eventTypes, offices, organizations }, updateEvent }) =>
+const EditEvent = ({
+  data: { networkStatus, event, eventTypes, offices, organizations },
+  updateEvent,
+  destroySignup,
+  createSignup,
+}) =>
   networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
@@ -20,6 +26,8 @@ const EditEvent = ({ data: { networkStatus, event, eventTypes, offices, organiza
       event={event}
       eventTypes={eventTypes}
       offices={offices}
+      users={event.users}
+      destroySignup={user => destroySignup(event, user)}
       organizations={organizations}
       onSubmit={updateEvent}
     />
@@ -61,6 +69,23 @@ const withData = compose(
           .catch(({ graphQLErrors }) => {
             ownProps.graphQLError('event', graphQLErrors)
           }),
+    }),
+  }),
+  graphql(DestroySignupMutation, {
+    props: ({ mutate }) => ({
+      destroySignup: (event, user) =>
+        mutate({
+          variables: { eventId: event.id, userId: user.id },
+          optimisticResponse: {
+            __typename: 'Mutation',
+            destroySignup: {
+              __typename: 'Signup',
+              event: R.merge(event, {
+                users: R.reject(u => u.id === user.id, event.users),
+              }),
+            },
+          },
+        }),
     }),
   })
 )

--- a/app/javascript/pages/admin/Events/edit.js
+++ b/app/javascript/pages/admin/Events/edit.js
@@ -17,7 +17,6 @@ const EditEvent = ({
   data: { networkStatus, event, eventTypes, offices, organizations },
   updateEvent,
   destroySignup,
-  createSignup,
 }) =>
   networkStatus === NetworkStatus.loading ? (
     <Loading />
@@ -60,7 +59,7 @@ const withData = compose(
     props: ({ ownProps, mutate }) => ({
       updateEvent: event =>
         mutate({
-          variables: { input: R.omit(['__typename'], extractIdFromAssociations(event)) },
+          variables: { input: R.omit(['__typename', 'users'], extractIdFromAssociations(event)) },
           optimisticResponse: buildOptimisticResponse(event),
         })
           .then(_response => {

--- a/app/javascript/pages/admin/Events/form.js
+++ b/app/javascript/pages/admin/Events/form.js
@@ -43,12 +43,24 @@ const validate = values => {
   return errors
 }
 
-const EventFormPage = ({ eventTypes, offices, organizations, handleSubmit, pristine, submitting, graphQLErrors }) => (
+const EventFormPage = ({
+  eventTypes,
+  offices,
+  organizations,
+  handleSubmit,
+  pristine,
+  submitting,
+  graphQLErrors,
+  users,
+  destroySignup,
+}) => (
   <EventForm
     eventTypes={eventTypes}
     offices={offices}
     organizations={organizations}
     handleSubmit={handleSubmit}
+    users={users}
+    destroySignup={destroySignup}
     disableSubmit={pristine || submitting}
     errors={graphQLErrors}
   />

--- a/app/javascript/pages/admin/Events/queries/show.gql
+++ b/app/javascript/pages/admin/Events/queries/show.gql
@@ -2,6 +2,7 @@
 #import "fragments/EventTypeEntry.gql"
 #import "fragments/OfficeEntry.gql"
 #import "fragments/OrganizationEntry.gql"
+#import "fragments/UserEntry.gql"
 
 query EventQuery($id: ID!) {
   event(id: $id) {
@@ -14,6 +15,9 @@ query EventQuery($id: ID!) {
     }
     organization {
       ...OrganizationEntry
+    }
+    users {
+      ...UserEntry
     }
   }
   eventTypes {


### PR DESCRIPTION
@zendesk/volunteer 

#87 introduced a bug that broke the query that updates events. The cause is unexpected field `users`. Thus #87 is reverted (see #113). 

This PR brings back #87 and omits the unexpected field.