### PR TITLE
Move reporting to admin section

### DIFF
--- a/app/javascript/components/Header/index.js
+++ b/app/javascript/components/Header/index.js
@@ -8,7 +8,6 @@ import MenuItem from 'material-ui/MenuItem'
 import Divider from 'material-ui/Divider'
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right'
 import ContentIcon from 'material-ui/svg-icons/content/create'
-import ReportingIcon from 'material-ui/svg-icons/av/equalizer'
 
 import s from './main.css'
 
@@ -25,13 +24,6 @@ const AdminActions = ({ currentUser }) =>
         <Link to="/portal/admin">
           <button className={s.btn}>
             <ContentIcon />
-          </button>
-        </Link>
-      </div>
-      <div className={s.adminBox}>
-        <Link to="/portal/admin/reporting">
-          <button className={s.btn}>
-            <ReportingIcon />
           </button>
         </Link>
       </div>

--- a/app/javascript/pages/admin/Admin/index.js
+++ b/app/javascript/pages/admin/Admin/index.js
@@ -5,6 +5,7 @@ import { graphql } from 'react-apollo'
 import { NetworkStatus } from 'apollo-client'
 import DropDownMenu from 'material-ui/DropDownMenu'
 import MenuItem from 'material-ui/MenuItem'
+import ReportingIcon from 'material-ui/svg-icons/av/equalizer'
 
 import { changeAdminOfficeFilter } from 'actions'
 
@@ -140,6 +141,10 @@ class Admin extends Component {
             <div className={s.navSpacer} />
             <Link to="/portal/admin/users">
               <span className={btnClass(routing, 'users')}>Users</span>
+            </Link>
+            <div className={s.navSpacer} />
+            <Link to="/portal/admin/reporting">
+              <span className={btnClass(routing, 'reporting')}>Reporting</span>
             </Link>
             <div className={`${s.navSpacer} ${s.growingSpace}`} />
             <OfficeFilter

--- a/app/javascript/pages/admin/Admin/index.js
+++ b/app/javascript/pages/admin/Admin/index.js
@@ -5,7 +5,6 @@ import { graphql } from 'react-apollo'
 import { NetworkStatus } from 'apollo-client'
 import DropDownMenu from 'material-ui/DropDownMenu'
 import MenuItem from 'material-ui/MenuItem'
-import ReportingIcon from 'material-ui/svg-icons/av/equalizer'
 
 import { changeAdminOfficeFilter } from 'actions'
 

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -29,7 +29,6 @@ export default (
   <div>
     <Route path="/portal" component={App}>
       {/* Admin Namespace */}
-      <Route path="/portal/admin/reporting" component={Reporting} />
       <Route path="/portal/admin" component={Admin}>
         <IndexRoute component={AdminDashboard} />
         <Route path="/portal/admin/events/new" component={NewEvent} />
@@ -47,6 +46,7 @@ export default (
         <Route path="/portal/admin/individual_events" component={IndividualEventsAdmin} />
         <Route path="/portal/admin/users/:id/edit" component={EditUser} />
         <Route path="/portal/admin/users" component={UsersAdmin} />
+        <Route path="/portal/admin/reporting" component={Reporting} />
         <Route path="*" component={AdminDashboard} />
       </Route>
       {/* Default Namespace */}


### PR DESCRIPTION
This changes the reporting button to be an admin tab. Previously we had tried to separate it from admin, but then we missed the office filter functionality.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/73)

## Screenshots (if needed)
<img width="998" alt="screen shot 2018-12-05 at 4 37 43 pm" src="https://user-images.githubusercontent.com/2517811/49492573-f4cdee00-f8ac-11e8-8478-b73573867313.png">

## CCs
@zendesk/volunteer

## Risks (if any)
* [low] users may struggle to find the reporting section
