### PR TITLE
Create new event type if doesn't exist before creating event

### DIFF
--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -109,6 +109,27 @@ const OrganizationField = ({ organizations, input: { value, onChange } }) => (
     menuStyle={{ overflowY: 'scroll', height: 200 }}
     openOnFocus
     fullWidth
+    openOnFocus
+  />
+)
+
+const EventTypeField = ({ eventTypes, input: { value, onChange } }) => (
+  <AutoComplete
+    id="eventType"
+    searchText={
+      value.newType ||
+      (R.isNil(value.id) || R.isEmpty(value.id) ? value.id : R.find(e => e.id === value.id, eventTypes).title)
+    }
+    dataSource={eventTypes}
+    dataSourceConfig={{ text: 'title', value: 'id' }}
+    filter={AutoComplete.fuzzyFilter}
+    onUpdateInput={(searchText, {}) => onChange({ newType: searchText })}
+    onNewRequest={(chosen, _i) => onChange({ id: chosen.id })}
+    className={s.muiTextField}
+    textFieldStyle={styles.muiTextField}
+    menuStyle={{ overflowY: 'scroll', height: 200 }}
+    fullWidth
+    openOnFocus
   />
 )
 
@@ -156,17 +177,14 @@ const EventForm = ({
     </div>
     <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
       <div className={s.column}>
-        <Field label="Event Type" className={s.field} name="eventType.id" component={renderField} type="select">
-          <option value="-" key="-" />
-          {R.map(
-            eventType => (
-              <option value={eventType.id} key={`eventType-${eventType.id}`}>
-                {eventType.title}
-              </option>
-            ),
-            eventTypes
-          )}
-        </Field>
+        <Field
+          label="Event Type"
+          className={s.field}
+          name="eventType"
+          component={renderField}
+          eventTypes={eventTypes}
+          Custom={EventTypeField}
+        />
       </div>
       <div className={s.column}>
         <Field


### PR DESCRIPTION
Create new event type if doesn't exist before creating event
Resolves #112 

## Description
As an admin creating an event, I expect a new Event type to be created if it doesn’t already exist

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/112)

## Implementation notes (if needed)
Refactored event type creation to be re-used.

## Tasks (if needed)
- [ ] Write tests ?

## Screenshots (if needed)
<details>
<summary>Event type is now an autocomplete field</summary>
<img width="493" alt="screen shot 2018-12-05 at 5 06 18 pm" src="https://user-images.githubusercontent.com/27116427/49493435-3e6c0800-f8b0-11e8-9204-7b8200414657.png">
</details>

<details>
<summary>Event Created</summary>
<img width="957" alt="screen shot 2018-12-05 at 5 06 49 pm" src="https://user-images.githubusercontent.com/27116427/49493436-3e6c0800-f8b0-11e8-9dbb-e813f7ed2eed.png">
</details>

<details>
<summary>Event Type Also Created</summary>
<img width="1000" alt="screen shot 2018-12-05 at 5 07 05 pm" src="https://user-images.githubusercontent.com/27116427/49493437-3e6c0800-f8b0-11e8-892a-8efac88f4c41.png">
</details>

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [HIGH | medium | low] - low
