### PR TITLE
[Issue 71] switch user profile edit location to dropdown from autocomplete

### DIFF
--- a/app/javascript/components/UserForm/index.js
+++ b/app/javascript/components/UserForm/index.js
@@ -71,19 +71,6 @@ const renderField = props => {
 
 const isNoErrors = errors => R.isNil(errors) || R.isEmpty(errors)
 
-const OfficeField = ({ offices, input: { value, onChange } }) => (
-  <AutoComplete
-    id="office"
-    searchText={R.isNil(value) || R.isEmpty(value) ? value : R.find(o => o.id === value, offices).name}
-    dataSource={offices}
-    dataSourceConfig={{ text: 'name', value: 'id' }}
-    filter={AutoComplete.fuzzyFilter}
-    onNewRequest={(chosen, _i) => onChange(chosen.id)}
-    className={s.muiTextField}
-    textFieldStyle={styles.muiTextField}
-  />
-)
-
 const UserForm = ({ handleSubmit, disableSubmit, errors, offices }) => {
   return (
     <form className={s.form} onSubmit={handleSubmit}>
@@ -111,15 +98,19 @@ const UserForm = ({ handleSubmit, disableSubmit, errors, offices }) => {
         <Field label="Admin" className={s.field} name="isAdmin" component={renderField} type="checkbox" />
       </div>
       <div className={s.inputGroup}>
-        <Field
-          label="Office"
-          className={s.field}
-          name="office.id"
-          component={renderField}
-          type="select"
-          offices={offices}
-          Custom={OfficeField}
-        />
+        <div className={s.column}>
+          <Field label="Office" className={s.field} name="office.id" component={renderField} type="select">
+            <option value="-" key="-" />
+            {R.map(
+              office => (
+                <option value={office.id} key={`office-${office.id}`}>
+                  {office.name}
+                </option>
+              ),
+              offices
+            )}
+          </Field>
+        </div>
       </div>
       <div className={s.inputGroup}>
         <button className={`${s.btn} ${s.primary}`} type="submit" disabled={disableSubmit}>


### PR DESCRIPTION
Switch the user profile edit location to dropdown from autocomplete

## Description
For consistency on the user profile edit page, change autocomplete box to dropdown.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/71)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img width="1123" alt="screen shot 2019-01-02 at 4 52 03 pm" src="https://user-images.githubusercontent.com/1825818/50581558-cf81cf00-0eae-11e9-8fe9-05bd1ef6b0ec.png">
</details>

<details>
<summary>After</summary>
<img width="1122" alt="screen shot 2019-01-02 at 4 51 36 pm" src="https://user-images.githubusercontent.com/1825818/50581550-c4c73a00-0eae-11e9-9ba5-209937b3978c.png">
</details>

## CCs

@xuebingli 

## Risks (if any)
* [low] ui change to admin only.  Might break the ability to update user location
