### PR TITLE
[Issue 123] Stop counting hours of future events

### DIFF
--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -28,7 +28,7 @@ const milestoneBarChunk = milestoneBarWidth / milestones.length
 
 // The server expects seconds since epoch, not milliseconds
 const startOfYear = Math.floor(moment().startOf('year') / 1000)
-const endOfYear = Math.ceil(moment().endOf('year') / 1000)
+const nowInSec = moment().unix()
 
 const leaderBoardSize = 10
 const leaderBoardSort = 'HOURS_DESC'
@@ -117,7 +117,7 @@ const milestoneLabelStyling = (item, milestone, user) => {
   return R.join(' ', classes)
 }
 
-const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users)
+const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users) // TODO: remove
 
 const LeaderboardContainer = ({
   data: { networkStatus, users, offices, currentUser },
@@ -162,7 +162,7 @@ const leaderboardWithData = graphql(LeaderboardQuery, {
       count: leaderBoardSize,
       sortBy: leaderBoardSort,
       after: startOfYear,
-      before: endOfYear,
+      before: nowInSec,
     }
 
     variables.officeId = dashboardOfficeFilter.value
@@ -237,7 +237,7 @@ const Dashboard = ({ data: { networkStatus, currentUser }, locationBeforeTransit
 
 const withData = graphql(MilestoneQuery, {
   options: {
-    variables: { after: startOfYear, before: endOfYear },
+    variables: { after: startOfYear, before: nowInSec },
     fetchPolicy: 'cache-and-network',
   },
 })

--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -117,7 +117,8 @@ const milestoneLabelStyling = (item, milestone, user) => {
   return R.join(' ', classes)
 }
 
-const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users) // TODO: remove
+// TODO: remove; sorting should be done on server side
+const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users)
 
 const LeaderboardContainer = ({
   data: { networkStatus, users, offices, currentUser },

--- a/app/javascript/pages/admin/Reporting/index.js
+++ b/app/javascript/pages/admin/Reporting/index.js
@@ -13,7 +13,7 @@ import ReportingQuery from './query.gql'
 import s from './main.css'
 
 const defaultStartDate = moment().startOf('year')
-const defaultEndDate = moment().endOf('year')
+const defaultEndDate = moment().valueOf() // Now in Unix millisecond timestamp
 
 const formatOrDefaultStartDate = filterValue => Number(moment(filterValue || defaultStartDate).format('X'))
 const formatOrDefaultEndDate = filterValue => Number(moment(filterValue || defaultEndDate).format('X'))


### PR DESCRIPTION
Closes #123.

## Description

For user-facing dashboard, stop counting hours of future events. One reason is that volunteers may drop out of future events, which leads to fluctuation in Top Volunteer rankings.

For admin-facing reporting session, though the end date filters defaults to *display* today, end of year is actually used as default end date. This PR fixes the issue.

## References

[Github Issue](https://github.com/zendesk/volunteer_portal/issues/123)

## CCs

@zendesk/volunteer

## Risks (if any)
* medium - user-facing dashboard shows incorrect volunteer hours
* medium - admin-facing reporting section shows incorrect volunteer hours
