### PR TITLE
require an admin to C_UD most resources

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -2,21 +2,28 @@ class GraphqlController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def execute
-    variables = ensure_hash(params[:variables])
-    context = {
-      current_user: current_user
-    }
-
     render json: PortalSchema.execute(params[:query],
       variables: variables,
       context: context,
       operation_name: params[:operationName])
+  rescue PortalSchema::MutationForbiddenError
+    handle_forbidden_mutation
   rescue => e
     raise e unless Rails.env.development?
     handle_error_in_development e
   end
 
   private
+
+  def variables
+    ensure_hash(params[:variables])
+  end
+
+  def context
+    {
+      current_user: current_user
+    }
+  end
 
   # Handle form data, JSON body, or a blank value
   def ensure_hash(ambiguous_param)
@@ -41,5 +48,13 @@ class GraphqlController < ApplicationController
     logger.error e.backtrace.join("\n")
 
     render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+  end
+
+  def handle_forbidden_mutation
+    render json: {
+      errors: [
+        { message: "You don't have permission to do this" }
+      ]
+    }, status: :forbidden
   end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -6,11 +6,13 @@ class GraphqlController < ApplicationController
       variables: variables,
       context: context,
       operation_name: params[:operationName])
+  rescue ActiveRecord::RecordNotFound => e
+    handle_record_not_found(e)
   rescue PortalSchema::MutationForbiddenError
     handle_forbidden_mutation
   rescue => e
     raise e unless Rails.env.development?
-    handle_error_in_development e
+    handle_error_in_development(e)
   end
 
   private
@@ -41,6 +43,14 @@ class GraphqlController < ApplicationController
     else
       raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
     end
+  end
+
+  def handle_record_not_found(exception)
+    render json: {
+      errors: [
+        { message: exception.message }
+      ]
+    }, status: :not_found
   end
 
   def handle_error_in_development(e)

--- a/app/graphql/mutations/approve_individual_event.rb
+++ b/app/graphql/mutations/approve_individual_event.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class ApproveIndividualEvent < BaseMutation
+    description 'Mark an individual event as approved'
+
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      event = IndividualEvent.find(id)
+      event.status = IndividualEvent::APPROVED
+      event.save!
+      event
+    end
+  end
+end

--- a/app/graphql/mutations/approve_individual_event.rb
+++ b/app/graphql/mutations/approve_individual_event.rb
@@ -1,5 +1,7 @@
 module Mutations
   class ApproveIndividualEvent < BaseMutation
+    require_admin
+
     description 'Mark an individual event as approved'
 
     null true

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,4 +1,4 @@
 module Mutations
-  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+  class BaseMutation < GraphQL::Schema::Mutation
   end
 end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,4 +1,8 @@
 module Mutations
   class BaseMutation < GraphQL::Schema::Mutation
+
+    def self.require_admin
+      self.include Concerns::RestrictToAdmin
+    end
   end
 end

--- a/app/graphql/mutations/concerns/restrict_to_admin.rb
+++ b/app/graphql/mutations/concerns/restrict_to_admin.rb
@@ -1,0 +1,11 @@
+module Mutations::Concerns
+  module RestrictToAdmin
+    def ready?(*)
+      if context[:current_user].role == Role.admin
+        return true
+      else
+        raise PortalSchema::MutationForbiddenError
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/create_edit_individual_event.rb
+++ b/app/graphql/mutations/create_edit_individual_event.rb
@@ -1,0 +1,28 @@
+module Mutations
+  class CreateEditIndividualEvent < BaseMutation
+    description "Create a new individual event for a logged-in user"
+
+    null true
+
+    argument :input, Types::Input::CreateEditIndividualEventInputType, required: true
+
+    def resolve(input:)
+      if input.id
+        IndividualEvent.find(input.id)
+      else
+        IndividualEvent.new
+      end.tap do |individual_event|
+        individual_event.description = input.description
+        individual_event.office_id = input.office_id
+        individual_event.user = context[:current_user]
+        individual_event.date = Time.at(input.date)
+        individual_event.duration = input.duration
+        individual_event.event_type_id = input.event_type_id
+        individual_event.organization_id = input.organization_id
+        individual_event.save!
+      end
+
+      context[:current_user]
+    end
+  end
+end

--- a/app/graphql/mutations/create_event.rb
+++ b/app/graphql/mutations/create_event.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class CreateEvent < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditEventInputType, required: true
+
+    def resolve(**args)
+      EventResolver.create(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/create_event.rb
+++ b/app/graphql/mutations/create_event.rb
@@ -1,5 +1,7 @@
 module Mutations
   class CreateEvent < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditEventInputType, required: true

--- a/app/graphql/mutations/create_event_type.rb
+++ b/app/graphql/mutations/create_event_type.rb
@@ -1,5 +1,7 @@
 module Mutations
   class CreateEventType < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditEventTypeInputType, required: true

--- a/app/graphql/mutations/create_event_type.rb
+++ b/app/graphql/mutations/create_event_type.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class CreateEventType < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditEventTypeInputType, required: true
+
+    def resolve(**args)
+      EventTypeResolver.create(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/create_office.rb
+++ b/app/graphql/mutations/create_office.rb
@@ -1,5 +1,7 @@
 module Mutations
   class CreateOffice < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditOfficeInputType, required: true

--- a/app/graphql/mutations/create_office.rb
+++ b/app/graphql/mutations/create_office.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class CreateOffice < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditOfficeInputType, required: true
+
+    def resolve(**args)
+      OfficeResolver.create(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/create_organization.rb
+++ b/app/graphql/mutations/create_organization.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class CreateOrganization < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditOrganizationInputType, required: true
+
+    def resolve(**args)
+      OrganizationResolver.create(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/create_organization.rb
+++ b/app/graphql/mutations/create_organization.rb
@@ -1,5 +1,7 @@
 module Mutations
   class CreateOrganization < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditOrganizationInputType, required: true

--- a/app/graphql/mutations/create_signup.rb
+++ b/app/graphql/mutations/create_signup.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class CreateSignup < BaseMutation
+    description 'Create a signup for the current user with the given event'
+
+    null true
+
+    argument :event_id, ID, required: true
+
+    def resolve(event_id:)
+      event = Event.find(event_id)
+      event.sign_up_user!(context[:current_user])
+      event.save!
+      event.signups.last
+    end
+  end
+end

--- a/app/graphql/mutations/delete_event.rb
+++ b/app/graphql/mutations/delete_event.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class DeleteEvent < BaseMutation
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      EventResolver.delete(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/delete_event.rb
+++ b/app/graphql/mutations/delete_event.rb
@@ -1,5 +1,7 @@
 module Mutations
   class DeleteEvent < BaseMutation
+    require_admin
+
     null true
 
     argument :id, ID, required: true

--- a/app/graphql/mutations/delete_event_type.rb
+++ b/app/graphql/mutations/delete_event_type.rb
@@ -1,5 +1,7 @@
 module Mutations
   class DeleteEventType < BaseMutation
+    require_admin
+
     null true
 
     argument :id, ID, required: true

--- a/app/graphql/mutations/delete_event_type.rb
+++ b/app/graphql/mutations/delete_event_type.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class DeleteEventType < BaseMutation
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      EventTypeResolver.delete(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/delete_individual_event.rb
+++ b/app/graphql/mutations/delete_individual_event.rb
@@ -1,0 +1,14 @@
+module Mutations
+  class DeleteIndividualEvent < BaseMutation
+    description "Create a new individual event for a logged-in user"
+
+    null true
+
+    argument :input, Types::Input::DeleteIndividualEventInputType, required: true
+
+    def resolve(input:)
+      IndividualEvent.destroy(input.id)
+      context[:current_user]
+    end
+  end
+end

--- a/app/graphql/mutations/delete_office.rb
+++ b/app/graphql/mutations/delete_office.rb
@@ -1,5 +1,7 @@
 module Mutations
   class DeleteOffice < BaseMutation
+    require_admin
+
     null true
 
     argument :id, ID, required: true

--- a/app/graphql/mutations/delete_office.rb
+++ b/app/graphql/mutations/delete_office.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class DeleteOffice < BaseMutation
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      OfficeResolver.delete(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/delete_organization.rb
+++ b/app/graphql/mutations/delete_organization.rb
@@ -1,5 +1,7 @@
 module Mutations
   class DeleteOrganization < BaseMutation
+    require_admin
+
     null true
 
     argument :id, ID, required: true

--- a/app/graphql/mutations/delete_organization.rb
+++ b/app/graphql/mutations/delete_organization.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class DeleteOrganization < BaseMutation
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      OrganizationResolver.delete(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/delete_user.rb
+++ b/app/graphql/mutations/delete_user.rb
@@ -1,5 +1,7 @@
 module Mutations
   class DeleteUser < BaseMutation
+    require_admin
+
     null true
 
     argument :id, ID, required: true

--- a/app/graphql/mutations/delete_user.rb
+++ b/app/graphql/mutations/delete_user.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class DeleteUser < BaseMutation
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(**args)
+      UserResolver.delete(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/destroy_signup.rb
+++ b/app/graphql/mutations/destroy_signup.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class DestroySignup < BaseMutation
+    description 'Destroy the given signup'
+
+    null true
+
+    argument :event_id, ID, required: true
+    argument :user_id,  ID, required: true
+
+    def resolve(event_id:, user_id:)
+      user = context[:current_user]
+      scope = user.role == Role.admin ? Signup : user.signups
+      signup = scope.find_by!(event_id: event_id, user_id: user_id)
+      signup.event.remove_user!(signup.user)
+      signup
+    end
+  end
+end

--- a/app/graphql/mutations/reject_individual_event.rb
+++ b/app/graphql/mutations/reject_individual_event.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class RejectIndividualEvent < BaseMutation
+    description 'Mark an individual event as rejected'
+
+    null true
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      event = IndividualEvent.find(id)
+      event.status = IndividualEvent::REJECTED
+      event.save!
+      event
+    end
+  end
+end

--- a/app/graphql/mutations/reject_individual_event.rb
+++ b/app/graphql/mutations/reject_individual_event.rb
@@ -1,5 +1,7 @@
 module Mutations
   class RejectIndividualEvent < BaseMutation
+    require_admin
+
     description 'Mark an individual event as rejected'
 
     null true

--- a/app/graphql/mutations/update_event.rb
+++ b/app/graphql/mutations/update_event.rb
@@ -1,5 +1,7 @@
 module Mutations
   class UpdateEvent < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditEventInputType, required: true

--- a/app/graphql/mutations/update_event.rb
+++ b/app/graphql/mutations/update_event.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class UpdateEvent < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditEventInputType, required: true
+
+    def resolve(**args)
+      EventResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/update_event_type.rb
+++ b/app/graphql/mutations/update_event_type.rb
@@ -1,5 +1,7 @@
 module Mutations
   class UpdateEventType < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditEventTypeInputType, required: true

--- a/app/graphql/mutations/update_event_type.rb
+++ b/app/graphql/mutations/update_event_type.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class UpdateEventType < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditEventTypeInputType, required: true
+
+    def resolve(**args)
+      EventTypeResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/update_office.rb
+++ b/app/graphql/mutations/update_office.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class UpdateOffice < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditOfficeInputType, required: true
+
+    def resolve(**args)
+      OfficeResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/update_office.rb
+++ b/app/graphql/mutations/update_office.rb
@@ -1,5 +1,7 @@
 module Mutations
   class UpdateOffice < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditOfficeInputType, required: true

--- a/app/graphql/mutations/update_organization.rb
+++ b/app/graphql/mutations/update_organization.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class UpdateOrganization < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditOrganizationInputType, required: true
+
+    def resolve(**args)
+      OrganizationResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/update_organization.rb
+++ b/app/graphql/mutations/update_organization.rb
@@ -1,5 +1,7 @@
 module Mutations
   class UpdateOrganization < BaseMutation
+    require_admin
+
     null true
 
     argument :input, Types::Input::EditOrganizationInputType, required: true

--- a/app/graphql/mutations/update_user.rb
+++ b/app/graphql/mutations/update_user.rb
@@ -1,0 +1,11 @@
+module Mutations
+  class UpdateUser < BaseMutation
+    null true
+
+    argument :input, Types::Input::EditUserInputType, required: true
+
+    def resolve(**args)
+      UserResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/mutations/update_user_office.rb
+++ b/app/graphql/mutations/update_user_office.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class UpdateUserOffice < BaseMutation
+    description 'Update the office of the current user object'
+
+    null true
+
+    argument :user_id,   ID, required: true
+    argument :office_id, ID, required: true
+
+    def resolve(user_id:, office_id:)
+      user = User.find(user_id)
+      office = Office.find(office_id)
+      user.office = office
+      user.save!
+      user
+    end
+  end
+end

--- a/app/graphql/portal_schema.rb
+++ b/app/graphql/portal_schema.rb
@@ -1,6 +1,9 @@
 require 'graphql/batch'
 
 class PortalSchema < GraphQL::Schema
+  class MutationForbiddenError < StandardError
+  end
+
   use GraphQL::Batch
 
   mutation(Types::MutationType)

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,200 +2,33 @@ module Types
   class MutationType < Types::BaseObject
     graphql_name "Mutation"
 
-    field :create_signup, SignupGraphType, null: true do
-      description 'Create a signup for the current user with the given event'
+    field :create_signup, SignupGraphType, mutation: Mutations::CreateSignup
+    field :destroy_signup, SignupGraphType, mutation: Mutations::DestroySignup
 
-      argument :event_id, ID, required: true
-    end
-    def create_signup(event_id:)
-      event = Event.find(event_id)
-      event.sign_up_user!(context[:current_user])
-      event.save!
-      event.signups.last
-    end
+    field :update_user_office, UserGraphType, mutation: Mutations::UpdateUserOffice
 
-    field :destroy_signup, SignupGraphType, null: true do
-      description 'Destroy the given signup'
+    field :create_edit_individual_event, UserGraphType, mutation: Mutations::CreateEditIndividualEvent
+    field :delete_individual_event, UserGraphType, mutation: Mutations::DeleteIndividualEvent
+    field :approve_individual_event, IndividualEventGraphType, mutation: Mutations::ApproveIndividualEvent
+    field :reject_individual_event, IndividualEventGraphType, mutation: Mutations::RejectIndividualEvent
 
-      argument :event_id, ID, required: true
-      argument :user_id,  ID, required: true
-    end
-    def destroy_signup(event_id:, user_id:)
-      user = context[:current_user]
-      scope = user.role == Role.admin ? Signup : user.signups
-      signup = scope.find_by!(event_id: event_id, user_id: user_id)
-      signup.event.remove_user!(signup.user)
-      signup
-    end
+    field :create_office, OfficeGraphType, mutation: Mutations::CreateOffice
+    field :update_office, OfficeGraphType, mutation: Mutations::UpdateOffice
+    field :delete_office, OfficeGraphType, mutation: Mutations::DeleteOffice
 
-    field :update_user_office, UserGraphType, null: true do
-      description 'Update the office of the current user object'
+    field :create_organization, OrganizationGraphType, mutation: Mutations::CreateOrganization
+    field :update_organization, OrganizationGraphType, mutation: Mutations::UpdateOrganization
+    field :delete_organization, OrganizationGraphType, mutation: Mutations::DeleteOrganization
 
-      argument :user_id,   ID, required: true
-      argument :office_id, ID, required: true
-    end
-    def update_user_office(user_id:, office_id:)
-      user = User.find(user_id)
-      office = Office.find(office_id)
-      user.office = office
-      user.save!
-      user
-    end
+    field :update_user, UserGraphType, mutation: Mutations::UpdateUser
+    field :delete_user, UserGraphType, mutation: Mutations::DeleteUser
 
-    field :create_edit_individual_event, UserGraphType, null: true do
-      description "Create a new individual event for a logged-in user"
+    field :create_event, EventGraphType, mutation: Mutations::CreateEvent
+    field :update_event, EventGraphType, mutation: Mutations::UpdateEvent
+    field :delete_event, EventGraphType, mutation: Mutations::DeleteEvent
 
-      argument :input, Input::CreateEditIndividualEventInputType, required: true
-    end
-    def create_edit_individual_event(input:)
-      if input.id
-        IndividualEvent.find(input.id)
-      else
-        IndividualEvent.new
-      end.tap do |individual_event|
-        individual_event.description = input.description
-        individual_event.office_id = input.office_id
-        individual_event.user = context[:current_user]
-        individual_event.date = Time.at(input.date)
-        individual_event.duration = input.duration
-        individual_event.event_type_id = input.event_type_id
-        individual_event.organization_id = input.organization_id
-        individual_event.save!
-      end
-
-      context[:current_user]
-    end
-
-    field :delete_individual_event, UserGraphType, null: true do
-      description "Create a new individual event for a logged-in user"
-
-      argument :input, Input::DeleteIndividualEventInputType, required: true
-    end
-    def delete_individual_event(input:)
-      IndividualEvent.destroy(input.id)
-      context[:current_user]
-    end
-
-    field :approve_individual_event, IndividualEventGraphType, null: true do
-      description 'Mark an individual event as approved'
-
-      argument :id, ID, required: true
-    end
-    def approve_individual_event(id:)
-      event = IndividualEvent.find(id)
-      event.status = IndividualEvent::APPROVED
-      event.save!
-      event
-    end
-
-    field :reject_individual_event, IndividualEventGraphType, null: true do
-      description 'Mark an individual event as rejected'
-
-      argument :id, ID, required: true
-    end
-    def reject_individual_event(id:)
-      event = IndividualEvent.find(id)
-      event.status = IndividualEvent::REJECTED
-      event.save!
-      event
-    end
-
-    field :create_office, OfficeGraphType, null: true do
-      argument :input, Input::EditOfficeInputType, required: true
-    end
-    def create_office(**args)
-      OfficeResolver.create(object, args, context)
-    end
-
-    field :update_office, OfficeGraphType, null: true do
-      argument :input, Input::EditOfficeInputType, required: true
-    end
-    def update_office(**args)
-      OfficeResolver.update(object, args, context)
-    end
-
-    field :delete_office, OfficeGraphType, null: true do
-      argument :id, ID, required: true
-    end
-    def delete_office(**args)
-      OfficeResolver.delete(object, args, context)
-    end
-
-    field :create_organization, OrganizationGraphType, null: true do
-      argument :input, Input::EditOrganizationInputType, required: true
-    end
-    def create_organization(**args)
-      OrganizationResolver.create(object, args, context)
-    end
-
-    field :update_organization, OrganizationGraphType, null: true do
-      argument :input, Input::EditOrganizationInputType, required: true
-    end
-    def update_organization(**args)
-      OrganizationResolver.update(object, args, context)
-    end
-
-    field :delete_organization, OrganizationGraphType, null: true do
-      argument :id, ID, required: true
-    end
-    def delete_organization(**args)
-      OrganizationResolver.delete(object, args, context)
-    end
-
-    field :update_user, UserGraphType, null: true do
-      argument :input, Input::EditUserInputType, required: true
-    end
-    def update_user(**args)
-      UserResolver.update(object, args, context)
-    end
-
-    field :delete_user, UserGraphType, null: true do
-      argument :id, ID, required: true
-    end
-    def delete_user(**args)
-      UserResolver.delete(object, args, context)
-    end
-
-    field :create_event, EventGraphType, null: true do
-      argument :input, Input::EditEventInputType, required: true
-    end
-    def create_event(**args)
-      EventResolver.create(object, args, context)
-    end
-
-    field :update_event, EventGraphType, null: true do
-      argument :input, Input::EditEventInputType, required: true
-    end
-    def update_event(**args)
-      EventResolver.update(object, args, context)
-    end
-
-    field :delete_event, EventGraphType, null: true do
-      argument :id, ID, required: true
-    end
-    def delete_event(**args)
-      EventResolver.delete(object, args, context)
-    end
-
-    field :create_event_type, EventTypeGraphType, null: true do
-      argument :input, Input::EditEventTypeInputType, required: true
-    end
-    def create_event_type(**args)
-      EventTypeResolver.create(object, args, context)
-    end
-
-    field :update_event_type, EventTypeGraphType, null: true do
-      argument :input, Input::EditEventTypeInputType, required: true
-    end
-    def update_event_type(**args)
-      EventTypeResolver.update(object, args, context)
-    end
-
-    field :delete_event_type, EventTypeGraphType, null: true do
-      argument :id, ID, required: true
-    end
-    def delete_event_type(**args)
-      EventTypeResolver.delete(object, args, context)
-    end
+    field :create_event_type, EventTypeGraphType, mutation: Mutations::CreateEventType
+    field :update_event_type, EventTypeGraphType, mutation: Mutations::UpdateEventType
+    field :delete_event_type, EventTypeGraphType, mutation: Mutations::DeleteEventType
   end
 end

--- a/test/graphql/mutations/concerns/restrict_to_admin_test.rb
+++ b/test/graphql/mutations/concerns/restrict_to_admin_test.rb
@@ -1,0 +1,35 @@
+require_relative '../../../test_helper'
+
+SingleCov.covered!
+
+describe Mutations::Concerns::RestrictToAdmin do
+  class TestMutation
+    include Mutations::Concerns::RestrictToAdmin
+  end
+
+  describe '#ready?' do
+    let(:context) { {} }
+
+    before do
+      TestMutation.any_instance.stubs(context: context)
+    end
+
+    describe 'current_user is an admin' do
+      let(:context) { { current_user: users(:admin) } }
+
+      it 'returns true' do
+        assert_equal true, TestMutation.new.ready?
+      end
+    end
+
+    describe 'current_user is a volunteer' do
+      let(:context) { { current_user: users(:a) } }
+
+      it 'raises an error' do
+        assert_raises PortalSchema::MutationForbiddenError do
+          TestMutation.new.ready?
+        end
+      end
+    end
+  end
+end

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -23,6 +23,27 @@ describe 'cleanliness' do
         app/controllers/ping_controller.rb
         app/controllers/standalone_controller.rb
         app/graphql/mutations/base_mutation.rb
+        app/graphql/mutations/create_event_type.rb
+        app/graphql/mutations/approve_individual_event.rb
+        app/graphql/mutations/create_signup.rb
+        app/graphql/mutations/delete_individual_event.rb
+        app/graphql/mutations/update_user.rb
+        app/graphql/mutations/delete_organization.rb
+        app/graphql/mutations/destroy_signup.rb
+        app/graphql/mutations/create_organization.rb
+        app/graphql/mutations/create_office.rb
+        app/graphql/mutations/update_organization.rb
+        app/graphql/mutations/reject_individual_event.rb
+        app/graphql/mutations/update_office.rb
+        app/graphql/mutations/delete_user.rb
+        app/graphql/mutations/create_edit_individual_event.rb
+        app/graphql/mutations/delete_event_type.rb
+        app/graphql/mutations/create_event.rb
+        app/graphql/mutations/delete_event.rb
+        app/graphql/mutations/delete_office.rb
+        app/graphql/mutations/update_event_type.rb
+        app/graphql/mutations/update_event.rb
+        app/graphql/mutations/update_user_office.rb
         app/graphql/portal_schema.rb
         app/graphql/resolvers/office_resolver.rb
         app/graphql/resolvers/organization_resolver.rb


### PR DESCRIPTION
## Description
This does two primary things. First, it converts every mutation to a class to map nicely to each GraphQL object that it is backing. Second, it adds a little helper to take advantage of the `Mutation#ready?` hook to perform authorization on most of the mutations. This will restrict the Create, Update, and Delete actions to admins for every resource with a few exceptions: 

- individual events are scoped to and managed by the current user
- the default office for a user is managed by that user
- signups can be created and destroyed by any user, but are scoped to the current user

resolves #124

it event has a nice little error message and valid JSON 

![screen shot 2019-01-23 at 3 05 01 pm](https://user-images.githubusercontent.com/6731804/51643436-53186400-1f21-11e9-9917-3a95ffd22d3d.png)

## CCs

@zendesk/volunteer

## Risks
* High - mutations could fail. This means it may break when trying to create/update/delete almost anything from the admin pages. Signing up for an event should be untouched. 