### PR TITLE
Fix date shifting bug

### DIFF
--- a/app/javascript/pages/Calendar/index.js
+++ b/app/javascript/pages/Calendar/index.js
@@ -141,15 +141,15 @@ const mapStateToProps = (state, ownProps) => {
 
 const momentAfter = Number(
   moment()
-    .startOf('month')
     .subtract(1, 'months')
+    .startOf('month')
     .format('X')
 )
 
 const momentBefore = Number(
   moment()
-    .endOf('month')
     .add(1, 'months')
+    .endOf('month')
     .format('X')
 )
 


### PR DESCRIPTION
This PR fixes bug that events on Mar 29 do not appear on calendar.

## Description

Current implementation (see below) fails to shift date to the end of next month in certain months.

```javascript
moment()
  .endOf('month')
  .add(1, 'months')
  .format('X')
```

Take Feb 14th for example. The code aboves shifts from Feb 14th to Feb 28th and finally to Mar 28th, instead of Mar 31st.

This PR proposes a simple fix that swaps the order of shifting function calls.

## Screenshots
<details>
<summary>Before</summary>
<img src="https://cl.ly/6bdadb2e3f79/Image%202019-02-27%20at%201.34.12%20pm.png" />
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/a8a937c6e52c/Image%202019-02-27%20at%201.33.41%20pm.png" />
</details>

## CCs

@zendesk/volunteer

## Risks
* low - under-fetching or over-fetching
