### PR TITLE
Admin dashboard bug fixes

### DIFF
--- a/app/javascript/pages/admin/Dashboard/attendanceQuery.gql
+++ b/app/javascript/pages/admin/Dashboard/attendanceQuery.gql
@@ -9,12 +9,7 @@ query AttendanceQuery($weekStart: Int, $weekEnd: Int, $monthStart: Int, $monthEn
   eventsThisMonth: events(after: $monthStart, before: $monthEnd, officeId: $officeId) {
     ...EventEntry
     duration
-    signups {
-      id
-      event {
-        id
-      }
-    }
+    signupCount
     users {
       id
     }
@@ -23,12 +18,7 @@ query AttendanceQuery($weekStart: Int, $weekEnd: Int, $monthStart: Int, $monthEn
   eventsThisWeek: events(after: $weekStart, before: $weekEnd, officeId: $officeId) {
     ...EventEntry
     duration
-    signups {
-      id
-      event {
-        id
-      }
-    }
+    signupCount
     users {
       id
     }

--- a/app/javascript/pages/admin/Dashboard/index.js
+++ b/app/javascript/pages/admin/Dashboard/index.js
@@ -59,16 +59,10 @@ const Dashboard = props => {
     return <Callout type="error" />
   }
 
-  const signupsThisWeek = R.flatten(R.map(event => event.signups, eventsThisWeek))
-  const signupsThisMonth = R.flatten(R.map(event => event.signups, eventsThisMonth))
+  const accumTotalMinutes = (acc, event) => acc + event.duration * event.signupCount
 
-  const volunteersThisWeek = R.length(signupsThisWeek)
-  const volunteersThisMonth = R.length(signupsThisMonth)
-
-  const hoursAppender = (hours, s) => [hours + R.find(e => e.id === s.event.id, allEvents).duration, s]
-
-  const minutesThisWeek = R.mapAccum(hoursAppender, 0, signupsThisWeek)[0]
-  const minutesThisMonth = R.mapAccum(hoursAppender, 0, signupsThisMonth)[0]
+  const minutesThisWeek = R.reduce(accumTotalMinutes, 0, eventsThisWeek)
+  const minutesThisMonth = R.reduce(accumTotalMinutes, 0, eventsThisMonth)
 
   const hoursThisWeek = Math.max(0, Math.round(minutesThisWeek / 60))
   const hoursThisMonth = Math.max(0, Math.round(minutesThisMonth / 60))
@@ -78,8 +72,12 @@ const Dashboard = props => {
   const spotsThisWeek = R.mapAccum(spotsAppender, 0, eventsThisWeek)[0]
   const spotsThisMonth = R.mapAccum(spotsAppender, 0, eventsThisMonth)[0]
 
-  const spotsFilledThisWeek = spotsThisWeek > 0 ? Math.round((volunteersThisWeek / spotsThisWeek) * 100) : 0
-  const spotsFilledThisMonth = spotsThisMonth > 0 ? Math.round((volunteersThisMonth / spotsThisMonth) * 100) : 0
+  const accumSignups = (acc, event) => acc + event.signupCount
+
+  const volunteersThisWeek = R.reduce(accumSignups, 0, eventsThisWeek)
+  const volunteersThisMonth = R.reduce(accumSignups, 0, eventsThisMonth)
+  const spotsFilledThisWeek = spotsThisWeek > 0 ? Math.round(volunteersThisWeek / spotsThisWeek * 100) : 0
+  const spotsFilledThisMonth = spotsThisMonth > 0 ? Math.round(volunteersThisMonth / spotsThisMonth * 100) : 0
 
   return (
     <div>
@@ -170,9 +168,6 @@ const mapStateToProps = (state, _ownProps) => ({
   adminOfficeFilter: state.model.adminOfficeFilter,
 })
 
-const withActions = connect(
-  mapStateToProps,
-  {}
-)
+const withActions = connect(mapStateToProps, {})
 
 export default withActions(withData(Dashboard))

--- a/app/javascript/pages/admin/Dashboard/index.js
+++ b/app/javascript/pages/admin/Dashboard/index.js
@@ -67,10 +67,10 @@ const Dashboard = props => {
   const hoursThisWeek = Math.max(0, Math.round(minutesThisWeek / 60))
   const hoursThisMonth = Math.max(0, Math.round(minutesThisMonth / 60))
 
-  const spotsAppender = (spots, e) => [spots + e.capacity, e]
+  const accumCapacity = (acc, event) => acc + event.capacity
 
-  const spotsThisWeek = R.mapAccum(spotsAppender, 0, eventsThisWeek)[0]
-  const spotsThisMonth = R.mapAccum(spotsAppender, 0, eventsThisMonth)[0]
+  const spotsThisWeek = R.reduce(accumCapacity, 0, eventsThisWeek)
+  const spotsThisMonth = R.reduce(accumCapacity, 0, eventsThisMonth)
 
   const accumSignups = (acc, event) => acc + event.signupCount
 


### PR DESCRIPTION
This PR proposes two bug fixes for admin dashboard.

## Description
1. Fix event participation bar on admin dashboard (see screenshot)
2. Close #132, by avoiding deprecated data loader 
3. Refactor unnecessary use of `mapAccum` with `reduce`

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/132)

## Screenshots
<details>
<summary>Before</summary>
<img src="https://cl.ly/5f9acfd4cc0c/Image%2525202019-02-27%252520at%2525203.41.54%252520pm.png">
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/0416a71c8584/Image%202019-02-27%20at%204.29.12%20pm.png">
</details>

## CCs

@zendesk/volunteer

## Risks
* HIGH - break analytics on admin dashboard
