### PR TITLE
skip default npm build on heroku because we use webpacker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "NODE_ENV=production webpack -p --progress --config webpack.config.prod.js",
     "precommit": "lint-staged",
-    "test": "jest"
+    "test": "jest",
+    "heroku-postbuild": "echo npm build is run by webpacker during rake assets:precompile"
   },
   "lint-staged": {
     "**/*.js": [


### PR DESCRIPTION
## Description

Heroku is going to start running `npm build` by default during the deploy process if you are using the Node.js pipeline. We are using webpacker which builds assets during the `rake asset:precompile` phase in the Ruby build. The documented way to opt-out of this is to define a `heroku-postbuild` script in `package.json`, which Heroku will run _instead_ of `npm build`. 

This adds a simple no-op script following the guide here: 
https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq

## CCs

@zendesk/volunteer

## Risks (if any)
* Low. Heroku deployments may fail or assets may be missing if we break the compile step.
