### PR TITLE
Changed organisation auto-complete components to open on focus and enabling scroll

### DIFF
--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -106,6 +106,8 @@ const OrganizationField = ({ organizations, input: { value, onChange } }) => (
     onNewRequest={(chosen, _i) => onChange(chosen.id)}
     className={s.muiTextField}
     textFieldStyle={styles.muiTextField}
+    menuStyle={{ overflowY: 'scroll', height: 200 }}
+    openOnFocus
     fullWidth
   />
 )

--- a/app/javascript/pages/IndividualEvents/index.js
+++ b/app/javascript/pages/IndividualEvents/index.js
@@ -77,6 +77,8 @@ const AutoCompleteField = ({ input: { value, onChange }, label, type, meta, data
       onNewRequest={(chosen, _i) => onChange(chosen.id)}
       className={s.muiTextField}
       textFieldStyle={styles.muiTextField}
+      menuStyle={{ overflowY: 'scroll', height: 200 }}
+      openOnFocus
       fullWidth
     />
   </div>


### PR DESCRIPTION
## Short description
Changed organisation auto-complete components to open on focus and enabling scroll. closes #141 

## Description
Changed all auto-complete components to open on focus (displays organisations without requiring filter), and also enable scrolling to stop overflow of large number of items spilling out of the screen. Height adjusted to 200 pixels which corresponds to 4 items to display at any one time.

First part of enabling open on focus is so users can search for organisations without knowing before hand their names. Currently the user must input a character before they can see and select an item from the drop down. This will allow users to identify the organisation in case they're not too sure on their name ("rings the bell" mentality here)

Some reasons include searching for "other" might result in a large list of items (using fuzzy filter), and subsequently overflowing over the screen, being unable to select the option..
Some considerations include changing the filtering method.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/141)

## Implementation notes
I don't always use this section, but I do when I find there's something particularly tricky end/or nifty in the code.

## Screenshots
<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/27116427/54253055-6e0e6880-45a1-11e9-94d4-b46988bdc494.png)

_items overflow_

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/27116427/54253040-5fc04c80-45a1-11e9-834e-37c4c61337a2.png)

</details>

## CCs

@zendesk/volunteer 

## Risks (if any)
* low
