### PR TITLE
Send individual event's date as string

### DIFF
--- a/app/graphql/mutations/create_edit_individual_event.rb
+++ b/app/graphql/mutations/create_edit_individual_event.rb
@@ -15,7 +15,7 @@ module Mutations
         individual_event.description = input.description
         individual_event.office_id = input.office_id
         individual_event.user = context[:current_user]
-        individual_event.date = Time.at(input.date)
+        individual_event.date = Date.parse(input.date)
         individual_event.duration = input.duration
         individual_event.event_type_id = input.event_type_id
         individual_event.organization_id = input.organization_id

--- a/app/graphql/types/input/create_edit_individual_event_input_type.rb
+++ b/app/graphql/types/input/create_edit_individual_event_input_type.rb
@@ -6,7 +6,7 @@ module Types::Input
     argument :id, ID, required: false, description: "Provide an id for an existing event"
     argument :description, String, required: true, description: "Description of an event"
     argument :office_id, ID, required: true, description: "Office the event takes places in"
-    argument :date, Int, required: true, description: "Date and time the event takes place"
+    argument :date, String, required: true, description: "Date and time the event takes place"
     argument :duration, Int, required: true, description: "Duration of event in minutes"
     argument :event_type_id, ID, required: true, description: "Type of event. ex: Mentoring"
     argument :organization_id, ID, required: true, description: "Organization with which the event is associated"

--- a/app/javascript/pages/IndividualEvents/index.js
+++ b/app/javascript/pages/IndividualEvents/index.js
@@ -355,18 +355,15 @@ const mapStateToProps = (state, _ownProps) => {
   return R.isNil(popover) ? props : R.merge({ initialValues: popover.data }, props)
 }
 
-const formDataToIndividualEventInput = data => {
-  const date = moment(data.date).unix()
-  return {
-    id: data.id,
-    description: data.description,
-    officeId: data.office.id,
-    date,
-    duration: parseInt(data.duration, 10),
-    eventTypeId: data.eventType.id,
-    organizationId: data.organization.id,
-  }
-}
+const formDataToIndividualEventInput = data => ({
+  id: data.id,
+  description: data.description,
+  officeId: data.office.id,
+  date: data.date.toString(),
+  duration: parseInt(data.duration, 10),
+  eventTypeId: data.eventType.id,
+  organizationId: data.organization.id,
+})
 
 const individualEventInputToOptimisticResponse = (data, input) => {
   return {


### PR DESCRIPTION
Closes #22.

## Description

Individual event's date is currently converted into unix timestamp before being sent to the backend. The backend then parses the timestamp (wrongly) in UTC timezone and saves the date into database.

This PR proposing sending date as string instead of as unix timestamp. This approach fixes #22, removes unnecessary encoding/decoding, and avoids dealing with timezone altogether.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/22)

## CCs

@zendesk/volunteer

## Risks (if any)
* low - individual events show wrong date
