### PR TITLE
Changed input location selection to drop down menu

### DIFF
--- a/app/javascript/components/LocationField/main.css
+++ b/app/javascript/components/LocationField/main.css
@@ -13,4 +13,25 @@
   color: #555;
   padding-left: 10px;
   margin: 0;
+  background: #fff;
+  max-height: 200px;
+  overflow: scroll;
+  position: absolute;
+  box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.25);
+  border-radius: 2px;
+  z-index: 1;
+  padding: 0;
+  max-width: 451px;
+}
+
+.autocompleteList li{
+  padding-left: 10px;
+  padding-right: 10px;
+  transition: background-color 0.3s;
+  cursor: pointer;
+}
+
+.autocompleteList li:hover{
+  background: #eee;
+  transition: background-color 0.3s;
 }


### PR DESCRIPTION
closes #7 

## Description
Changed geo suggestions to pop over, under the input field, so it doesn't push the other contents down.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/7)

## Implementation notes (if needed)
Styles to somewhat match the material theme. 

The `451px` corresponds to the "input field's" max-width in the 'create event page' (see screenshot). Although the 'create organisation page' also uses this, 451px appears to be the lesser of the two

## Screenshots (if needed)
<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/27116427/54322275-a4eb8980-4648-11e9-980f-b15ecfe50985.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/27116427/54322283-afa61e80-4648-11e9-85ca-16d954df2de8.png)

Darker background only appears on hover, (also, the cursor is a "pointer", suggests clicking)
</details>

## CCs

@zendesk/volunteer 

## Risks (if any)
* low
