### PR TITLE
Added clone event functionality

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -24,6 +24,7 @@ const eventsSort = 'STARTS_AT_DESC'
 const actionLinks = (event, deleteEvent) => (
   <div className={s.actionColumn}>
     <Link to={`/portal/admin/events/${event.id}/edit`}>Edit</Link>
+    <Link to={`/portal/admin/events/new/${event.id}`}>Clone</Link>
     <button className={`${s.deleteAction}`} onClick={() => deleteEvent(event)}>
       Delete
     </button>
@@ -66,7 +67,7 @@ const columns = deleteEvent => [
     Header: 'Actions',
     accessor: 'id',
     sortable: false,
-    width: 130,
+    width: 150,
     Cell: ({ original }) => actionLinks(original, deleteEvent),
   },
 ]
@@ -200,11 +201,8 @@ function mapStateToProps(state, _ownProps) {
   }
 }
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  graphQLError,
+})
 
 export default withActions(withData(Events))

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -15,11 +15,38 @@ import CreateEventMutation from './mutations/create.gql'
 
 import Loading from 'components/LoadingIcon'
 
-const NewEvent = ({ createEvent, data: { networkStatus, eventTypes, offices, organizations } }) =>
+const formShapeTransform = event => {
+  if (event) {
+    const { endsAt, eventType, office, organization, startsAt, id, users, __typename, ...rest } = {
+      ...event,
+      id: null,
+      users: null,
+      __typename: null,
+    }
+    return {
+      ...rest,
+      endsAt: new Date(endsAt),
+      eventType: { id: eventType.id },
+      office: { id: office.id },
+      organization: { id: organization.id },
+      startsAt: new Date(startsAt),
+    }
+  } else {
+    return event
+  }
+}
+
+const NewEvent = ({ createEvent, data: { networkStatus, event, eventTypes, offices, organizations } }) =>
   networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
-    <EventForm eventTypes={eventTypes} offices={offices} organizations={organizations} onSubmit={createEvent} />
+    <EventForm
+      event={formShapeTransform(event)}
+      eventTypes={eventTypes}
+      offices={offices}
+      organizations={organizations}
+      onSubmit={createEvent}
+    />
   )
 
 const buildOptimisticResponse = ({
@@ -54,11 +81,11 @@ const buildOptimisticResponse = ({
 
 const withData = compose(
   graphql(EventQuery, {
-    options: {
+    options: ({ params: { id } }) => ({
       variables: {
-        id: '-1',
+        id: id || '-1',
       },
-    },
+    }),
   }),
   graphql(CreateEventMutation, {
     props: ({ ownProps, mutate }) => ({

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -15,24 +15,18 @@ import CreateEventMutation from './mutations/create.gql'
 
 import Loading from 'components/LoadingIcon'
 
-const formShapeTransform = event => {
-  if (event) {
-    const { endsAt, eventType, office, organization, startsAt, id, users, __typename, ...rest } = {
-      ...event,
-      id: null,
-      users: null,
-      __typename: null,
-    }
-    return {
-      ...rest,
-      endsAt: new Date(endsAt),
-      eventType: { id: eventType.id },
-      office: { id: office.id },
-      organization: { id: organization.id },
-      startsAt: new Date(startsAt),
-    }
-  } else {
-    return event
+const transformToReduxFormState = event => {
+  const { title, description, capacity, location, startsAt, endsAt, eventType, office, organization } = event
+  return {
+    title,
+    description,
+    location,
+    capacity,
+    startsAt: new Date(startsAt),
+    endsAt: new Date(endsAt),
+    eventType: { id: eventType.id },
+    office: { id: office.id },
+    organization: { id: organization.id },
   }
 }
 
@@ -41,7 +35,7 @@ const NewEvent = ({ createEvent, data: { networkStatus, event, eventTypes, offic
     <Loading />
   ) : (
     <EventForm
-      event={formShapeTransform(event)}
+      event={event && transformToReduxFormState(event)}
       eventTypes={eventTypes}
       offices={offices}
       organizations={organizations}

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -31,7 +31,7 @@ export default (
       {/* Admin Namespace */}
       <Route path="/portal/admin" component={Admin}>
         <IndexRoute component={AdminDashboard} />
-        <Route path="/portal/admin/events/new" component={NewEvent} />
+        <Route path="/portal/admin/events/new(/:id)" component={NewEvent} />
         <Route path="/portal/admin/events/:id/edit" component={EditEvent} />
         <Route path="/portal/admin/events" component={EventsAdmin} />
         <Route path="/portal/admin/offices/new" component={NewOffice} />


### PR DESCRIPTION
## Short description

closes #16 
- New event accepts url parameters (event-id) for pre-fill
- Event dashboard ability to clone event by linking to above mentioned url `.../portal/admin/events/new/78` would pre-fill 'new event' page with the contents of event id 64.

## Description
Admins would like to create clone events that occur frequently without having to fill in the same information again. In particular, reoccuring events. This will let admins clone existing events by:
- Going to the Event admin page
- Clicking clone next to the event
- They will be prompted to create a new event, with the data pre-filled (cloned)

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/16)

## Implementation notes (if needed)
- Modifies the new event page to accept a url parameter to pre-fill data
- Optional url parameter field, if no parameter is provided, it is the normal new event page

## Screenshots (if needed)

![image](https://user-images.githubusercontent.com/27116427/55054204-113ba380-50b3-11e9-88df-f2fb172ae99e.png)

☝️click clone
👇pre-fills data (located at `http://localhost:5000/portal/admin/events/new/78`)

![image](https://user-images.githubusercontent.com/27116427/55054215-18fb4800-50b3-11e9-86ca-8b90968fc46d.png)


## CCs

@zendesk/volunteer


## Risks (if any)
* low
