### PR TITLE
Added capacity annotation to signal max capacity of event in the event details

### DIFF
--- a/app/javascript/pages/Event/index.js
+++ b/app/javascript/pages/Event/index.js
@@ -152,6 +152,9 @@ const Event = ({ data: { loading, event, currentUser }, createSignup, destroySig
                     destroySignupHandler={() => destroySignup(event, currentUser)}
                   />
                 </div>
+                <div className={s.capacityAnnotation}>
+                  <span>Capacity: {event.capacity}</span>
+                </div>
               </div>
               <UserList users={event.users} />
             </Section>

--- a/app/javascript/pages/Event/main.css
+++ b/app/javascript/pages/Event/main.css
@@ -134,3 +134,7 @@
   margin-bottom: 20px;
   border-bottom: 1px solid #ddd;
 }
+
+.capacityAnnotation {
+  font-size: 12px;
+}


### PR DESCRIPTION
resolves #86 

## Description
As described in issue #86, sometimes when the event is almost full, it can be hard to see how many spots are left. No where else is the maximum capacity indicated anywhere else on the event page. This solves the issue by adding a "capacity" annotation below where users are most likely to be looking for attendance information.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/86)

## Implementation notes
Small font was used to make sure it doesn't take up too much visual attention.


## Screenshots
### Before

![image](https://user-images.githubusercontent.com/27116427/55853093-f3863800-5ba2-11e9-935a-a82fe24d2764.png)

### After

![image](https://user-images.githubusercontent.com/27116427/55853077-dcdfe100-5ba2-11e9-867c-f5ed1385f207.png)

