### PR TITLE
Set event duration

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,6 +18,8 @@ class Event < ApplicationRecord
   validate :max_capacity
   validate :time_sequentiality
 
+  before_save :set_duration
+
   scope :before,     ->(time) { where("starts_at < ?", time) }
   scope :after,      ->(time) { where("starts_at > ?", time) }
   scope :in_month,   ->(month) { where('EXTRACT(MONTH from starts_at) = ?', month) }
@@ -66,5 +68,11 @@ class Event < ApplicationRecord
 
   def notify_websocket(action_type)
     ActionCable.server.broadcast 'events', type: action_type, event: self
+  end
+
+  def set_duration
+    if ends_at_changed? || starts_at_changed?
+      self.duration = (ends_at - starts_at) / 60
+    end
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -76,6 +76,31 @@ describe Event do
     end
   end
 
+  describe '#set_duration' do
+    it 'sets duration when new event is created' do
+      event = Event.new(
+        organization: organizations(:kittens), type: event_types(:group),
+        title: 'イベント', starts_at: Time.now, ends_at: (Time.now + 2.hours), capacity: 60,
+        location: 'Location', office: sf)
+      assert event.save
+      assert event.duration == 120
+    end
+
+    it 'sets duration when start and end times are updated' do
+      event = events(:minimum)
+      event.starts_at = Time.now
+      event.ends_at = Time.now + 2.hours
+      assert event.save
+      assert event.duration == 120
+    end
+
+    it 'does not set duration when start and end times are not updated' do
+      event = events(:minimum)
+      assert event.save
+      assert_nil event.duration
+    end
+  end
+
   it "creates event" do
     event = Event.new(
       organization: organizations(:kittens), type: event_types(:group),


### PR DESCRIPTION
Short description
Set event duration

## Description
In the individual_events table, we capture start time and duration, but we only capture start and end times in the events table without duration. This change will populate the duration column for events, because it will make it much simpler to union the 2 tables for finding and sorting top volunteers. 

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/53)

## Implementation notes (if needed)
N/A

## Tasks (if needed)
- [x] Write tests

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="drag_and_drop_snapshot_from_desktop_1.png">
</details>

<details>
<summary>After</summary>
<img src="drag_and_drop_snapshot_from_desktop_1.png">
</details>

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [low] - no user visible defect, but can impact future work if duration is not populated correctly
