### PR TITLE
Remove unused field from admin interface

### DIFF
--- a/app/javascript/pages/admin/Organizations/index.js
+++ b/app/javascript/pages/admin/Organizations/index.js
@@ -35,11 +35,6 @@ const columns = togglePopover => [
     filterable: true,
   },
   {
-    Header: 'Timezone',
-    accessor: 'timezone',
-    sortable: false,
-  },
-  {
     Header: 'Actions',
     accessor: 'id',
     sortable: false,
@@ -191,12 +186,9 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-    togglePopover,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  graphQLError,
+  togglePopover,
+})
 
 export default withActions(withData(Organizations))

--- a/app/javascript/pages/admin/Organizations/index.js
+++ b/app/javascript/pages/admin/Organizations/index.js
@@ -35,6 +35,11 @@ const columns = togglePopover => [
     filterable: true,
   },
   {
+    Header: 'Location',
+    accessor: 'location',
+    sortable: false,
+  },
+  {
     Header: 'Actions',
     accessor: 'id',
     sortable: false,

--- a/app/javascript/pages/admin/Users/index.js
+++ b/app/javascript/pages/admin/Users/index.js
@@ -35,11 +35,6 @@ const columns = togglePopover => [
     filterable: true,
   },
   {
-    Header: 'Timezone',
-    accessor: 'timezone',
-    sortable: false,
-  },
-  {
     Header: 'Actions',
     accessor: 'id',
     sortable: false,
@@ -175,12 +170,9 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-    togglePopover,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  graphQLError,
+  togglePopover,
+})
 
 export default withActions(withData(Users))

--- a/app/javascript/pages/admin/Users/index.js
+++ b/app/javascript/pages/admin/Users/index.js
@@ -35,6 +35,16 @@ const columns = togglePopover => [
     filterable: true,
   },
   {
+    Header: 'Email',
+    accessor: 'email',
+    filterable: true,
+  },
+  {
+    Header: 'Group',
+    accessor: 'group',
+    sortable: false,
+  },
+  {
     Header: 'Actions',
     accessor: 'id',
     sortable: false,


### PR DESCRIPTION
Fix #77 with an aim to replace #108 

## Description

- Remove timezone field from admin organization page
- Add location field to admin organization page
- Remove timezone field from admin user page
- Add user field and group field to admin organization page

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/77)

## Screenshots

### Organization Section

<details>
<summary>Before</summary>
<img src="https://cl.ly/dd8993fca345/Image%202019-05-22%20at%202.16.55%20pm.png">
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/dbb6cc756c97/Image%202019-05-22%20at%202.17.12%20pm.png">
</details>

### User Section
<details>
<summary>Before</summary>
<img src="https://cl.ly/b5bf80493a38/Image%202019-05-22%20at%202.16.13%20pm.png">
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/6b870ab257bf/Image%202019-05-22%20at%202.15.44%20pm.png">
</details>

## CCs

@zendesk/volunteer

## Risks (if any)
* low - admin interface is not properly rendered
