### PR TITLE
Ability for users to clone individual events

### DIFF
--- a/app/javascript/pages/MyEvents/index.js
+++ b/app/javascript/pages/MyEvents/index.js
@@ -146,7 +146,7 @@ const renderField = props => {
 
 const CreateEditDialog = ({ offices, eventTypes, organizations, onCancel, popover, onSubmit }) => {
   const event = popover.data
-  const isNewEvent = R.isNil(event) || (event && event.isNew)
+  const isNewEvent = event.isNew
   return (
     <Dialog
       title={isNewEvent ? 'Create Event' : 'Edit Event'}
@@ -346,7 +346,7 @@ const IndividualEvents = props => {
     <div className={s.eventsTable}>
       <div className={s.personalHeader}>
         <div className={s.actionBar}>
-          <button className={s.createAction} onClick={() => togglePopover('editIndividualEvent')}>
+          <button className={s.createAction} onClick={() => togglePopover('editIndividualEvent', { isNew: true })}>
             Add Event
           </button>
         </div>

--- a/app/javascript/pages/MyEvents/index.js
+++ b/app/javascript/pages/MyEvents/index.js
@@ -146,7 +146,7 @@ const renderField = props => {
 
 const CreateEditDialog = ({ offices, eventTypes, organizations, onCancel, popover, onSubmit }) => {
   const event = popover.data
-  const isNewEvent = R.isNil(event)
+  const isNewEvent = R.isNil(event) || (event && event.isNew)
   return (
     <Dialog
       title={isNewEvent ? 'Create Event' : 'Edit Event'}
@@ -305,6 +305,7 @@ const IndividualEvents = props => {
       Header: 'Actions',
       accessor: d => d,
       sortable: false,
+      width: 200,
       Cell: props => (
         <span className="s.actionColumn">
           <button
@@ -312,6 +313,23 @@ const IndividualEvents = props => {
             onClick={() => togglePopover('editIndividualEvent', props.value)}
           >
             Edit
+          </button>
+          <button
+            className={`${s.btn} ${s.confirmBtn}`}
+            onClick={() => {
+              const { description, office, date, duration, eventType, organization } = props.value
+              togglePopover('editIndividualEvent', {
+                description,
+                office,
+                date,
+                duration,
+                eventType,
+                organization,
+                isNew: true,
+              })
+            }}
+          >
+            Clone
           </button>
           <button
             className={`${s.btn} ${s.deleteBtn}`}


### PR DESCRIPTION
Solves #157

## Description
Sometimes users do individual events on a regular basis. This makes it easy so they don't have to re-fill the same information every occasion.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/157)

## Implementation notes (if needed)
Piggy backs off a lot of code so not much code changes.

Also note that we pre-fill date, so it makes it easy for users to select a date relative to that date (one week after being the row below) instead of current date where users have to navigate to date. Alternative suggestions welcome.

## Screenshots (if needed)
<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/27116427/58154254-87741500-7cb4-11e9-929b-3383b5a85277.png)


</details>

### After

![image](https://user-images.githubusercontent.com/27116427/58154918-133a7100-7cb6-11e9-88ef-0a06b5c4ee3d.png)

Clicking clone → 👇 Pre-fill

![image](https://user-images.githubusercontent.com/27116427/58154949-31a06c80-7cb6-11e9-987f-81bac4af1b2a.png)

## CCs

@zendesk/volunteer

## Risks
* low
