### PR TITLE
Adjust columns of admin events table

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -39,29 +39,35 @@ const columns = deleteEvent => [
     filterable: true,
   },
   {
-    Header: 'Office',
-    accessor: 'office.name',
-    minWidth: 70,
-    sortable: true,
-    filterable: true,
-  },
-  {
-    Header: 'Description',
-    accessor: 'description',
+    Header: 'Organization',
+    accessor: 'organization.name',
     sortable: true,
     filterable: true,
   },
   {
     Header: 'Start',
     accessor: 'startsAt',
+    width: 130,
     sortable: true,
-    Cell: ({ value }) => moment(value).format('h:mm a, MMM D, Y'),
+    Cell: ({ value }) => moment(value).format('MMM DD, Y'),
   },
   {
-    Header: 'End',
-    accessor: 'endsAt',
+    id: 'duration',
+    Header: 'Duration',
+    width: 80,
+    accessor: e => {
+      let start = moment(e.startsAt)
+      let end = moment(e.endsAt)
+      let diff = end.diff(start)
+      return moment.utc(diff).format('H:mm')
+    },
     sortable: true,
-    Cell: ({ value }) => moment(value).format('h:mm a, MMM D, Y'),
+  },
+  {
+    Header: 'Participants',
+    accessor: 'signupCount',
+    width: 120,
+    sortable: true,
   },
   {
     Header: 'Actions',

--- a/app/javascript/pages/admin/Events/queries/index.gql
+++ b/app/javascript/pages/admin/Events/queries/index.gql
@@ -9,9 +9,12 @@ query EventsQuery($officeId: ID, $sortBy: EventSortEnum,) {
   }
   events(officeId: $officeId, sortBy: $sortBy) {
     ...EventEntry
+    signupCount
     office {
       ...OfficeEntry
     }
-    duration
+    organization {
+      name
+    }
   }
 }


### PR DESCRIPTION
Closes #56.

## Description

Revamp columns on admin events page.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/56)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://cl.ly/b10dfd854a3f/Image%202019-06-19%20at%201.03.39%20pm.png">
</details>

<details>
<summary>After</summary>
<img src="https://cl.ly/67d7c7746f81/Image%202019-06-19%20at%201.04.28%20pm.png">
</details>

## CCs

@zendesk/volunteer

## Risks (if any)
* low - break rendering of events page
