### PR TITLE
Add backfill rake task for event duration

### DIFF
--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -1,0 +1,10 @@
+namespace :backfill do
+  desc "Backfill the duration field for events"
+  task duration: :environment do
+    ActiveRecord::Base.transaction do
+      Event.where(duration:nil).each do |e|
+        e.update! duration: (e.ends_at - e.starts_at) / 60
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make progress against #53 

## Description
Previously, we started to populate the duration of an event. This change adds a task to backfill the events with a duration. This moves us a step closer to resolving the issue with incorrect top volunteers on the dashboard.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/53)


## CCs

If app migration related
@zendesk/volunteer

Anyone specific?
@xuebingli 

## Risks (if any)
* [medium] - change has been tested locally and verified against the equivalent SQL query, but wholesale changes like this carries some other non-specific risks.
