### PR TITLE
Remove upper limit on individual events to support quarterly input

### DIFF
--- a/app/javascript/pages/MyEvents/index.js
+++ b/app/javascript/pages/MyEvents/index.js
@@ -99,8 +99,6 @@ const validate = values => {
   }
   if (!values.duration) {
     errors.duration = 'is required'
-  } else if (values.duration > 24 * 60) {
-    errors.duration = 'must be less than or equal to 24 hours'
   }
   if (!values.eventType) {
     errors.eventType = {}

--- a/app/models/individual_event.rb
+++ b/app/models/individual_event.rb
@@ -13,8 +13,7 @@ class IndividualEvent < ApplicationRecord
   validates :user, :organization, :event_type, :office,
             :description, :date, presence: true
   validates :duration, numericality: { only_integer: true,
-                                       greater_than: 0,
-                                       less_than_or_equal_to: 1440 }
+                                       greater_than: 0 }
 
   scope :for_user, ->(user) { where(user: user) }
   scope :before,   ->(date) { where("date < ?", date) }


### PR DESCRIPTION
Remove upper limit on individual events 
## Description
In Zendesk, we sometimes do quarterly reporting on events that are recurring. These can sometimes accumulate to more than 24 hours total. While it is important that the input be validated for being a number and for being greater than zero, members should be able to set whatever length is necessary to capture their work.


## CCs
@zendesk/volunteer


## Risks (if any)
low - participants should see no change other than removal of input upper limit
