### PR TITLE
Fix: Github security alert fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
     actionpack (5.1.6)
-      actionview (= 5.1.6)
+      actionview (= 5.1.6.2)
       activesupport (= 5.1.6)
       rack (~> 2.0)
       rack-test (>= 0.6.3)

--- a/app/javascript/components/App/__snapshots__/test.js.snap
+++ b/app/javascript/components/App/__snapshots__/test.js.snap
@@ -403,6 +403,7 @@ exports[`loads 1`] = `
         "color": "#ffffff",
         "rippleBackgroundColor": "#616161",
       },
+      "userAgent": undefined,
       "zIndex": Object {
         "appBar": 1100,
         "dialog": 1500,


### PR DESCRIPTION
## Description
Upgrade gem version and npm package version based on Github security alerts

## References
https://github.com/zendesk/volunteer_portal/network/alerts
