### PR TITLE
Properly Check If Apollo Client Is Loading

### DIFF
--- a/app/javascript/pages/App/index.js
+++ b/app/javascript/pages/App/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import R from 'ramda'
 import { compose, graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 
@@ -19,17 +18,11 @@ class AppPage extends Component {
   }
 
   render() {
-    const {
-      data: { networkStatus, currentUser, offices },
-      togglePopover,
-      popover,
-      children,
-      updateUserOffice,
-    } = this.props
+    const { data: { loading, currentUser, offices }, togglePopover, popover, children, updateUserOffice } = this.props
 
     return (
       <App
-        loading={networkStatus === NetworkStatus.loading}
+        loading={loading}
         currentUser={currentUser}
         offices={offices}
         userPopover={popover && popover.type === 'user' ? popover : null}

--- a/app/javascript/pages/Calendar/index.js
+++ b/app/javascript/pages/Calendar/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { compose, graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 import moment from 'moment'
@@ -47,18 +46,11 @@ const fetchMoreEvents = (fetchMore, calendarDateChange, currentDate, newDate, sc
 }
 
 const EventPopoverForData = props => {
-  const {
-    popoverState,
-    currentUser,
-    onPopoverClose,
-    createSignup,
-    destroySignup,
-    data: { networkStatus, event },
-  } = props
+  const { popoverState, currentUser, onPopoverClose, createSignup, destroySignup, data: { loading, event } } = props
 
   return (
     <EventPopover
-      loading={networkStatus === NetworkStatus.loading}
+      loading={loading}
       open
       anchorEl={popoverState.anchorEl}
       currentUser={currentUser}
@@ -81,7 +73,7 @@ const connectEventPopoverToData = graphql(EventQuery, {
 const EventPopoverWithData = connectEventPopoverToData(EventPopoverForData)
 
 const CalendarPage = ({
-  data: { networkStatus, fetchMore, currentUser, events, offices },
+  data: { loading, fetchMore, currentUser, events, offices },
   locationBeforeTransitions,
   filters,
   eventPopover,
@@ -96,7 +88,7 @@ const CalendarPage = ({
 }) => (
   <div>
     <Calendar
-      loading={networkStatus === NetworkStatus.loading}
+      loading={loading}
       currentPath={locationBeforeTransitions.pathname}
       events={events}
       offices={offices}

--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 import moment from 'moment'
@@ -121,11 +120,11 @@ const milestoneLabelStyling = (item, milestone, user) => {
 const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users)
 
 const LeaderboardContainer = ({
-  data: { networkStatus, users, offices, currentUser },
+  data: { loading, users, offices, currentUser },
   dashboardOfficeFilter,
   changeDashboardOfficeFilter,
 }) =>
-  networkStatus === NetworkStatus.loading ? (
+  loading ? (
     <Loading />
   ) : (
     <div className={s.leaderboard}>
@@ -177,8 +176,8 @@ const leaderboardWithData = graphql(LeaderboardQuery, {
 const leaderboardWithActions = connect(mapStateToProps, { changeDashboardOfficeFilter })
 const Leaderboard = leaderboardWithActions(leaderboardWithData(LeaderboardContainer))
 
-const Dashboard = ({ data: { networkStatus, currentUser }, locationBeforeTransitions }) => {
-  if (networkStatus === NetworkStatus.loading) {
+const Dashboard = ({ data: { loading, currentUser }, locationBeforeTransitions }) => {
+  if (loading) {
     return <Loading />
   } else {
     const activeMilestone = selectMilestone(currentUser.hours)

--- a/app/javascript/pages/admin/Admin/index.js
+++ b/app/javascript/pages/admin/Admin/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router'
 import { graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import DropDownMenu from 'material-ui/DropDownMenu'
 import MenuItem from 'material-ui/MenuItem'
 
@@ -87,9 +86,9 @@ const OfficeFilter = ({ adminOfficeFilter, changeAdminOfficeFilter, offices }) =
 
 class Admin extends Component {
   componentDidUpdate() {
-    const { history, data: { networkStatus, currentUser } } = this.props
+    const { history, data: { loading, currentUser } } = this.props
 
-    if (networkStatus !== NetworkStatus.loading && !currentUser.isAdmin) {
+    if (!loading && !currentUser.isAdmin) {
       history.push('/portal')
     }
   }

--- a/app/javascript/pages/admin/EventTypes/edit.js
+++ b/app/javascript/pages/admin/EventTypes/edit.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 
@@ -12,12 +11,8 @@ import Loading from 'components/LoadingIcon'
 import EventTypeQuery from './queries/show.gql'
 import UpdateEventTypeMutation from './mutations/update.gql'
 
-const EditEventType = ({ data: { networkStatus, eventType }, updateEventType }) =>
-  networkStatus === NetworkStatus.loading ? (
-    <Loading />
-  ) : (
-    <EventTypeForm eventType={eventType} onSubmit={updateEventType} />
-  )
+const EditEventType = ({ data: { loading, eventType }, updateEventType }) =>
+  loading ? <Loading /> : <EventTypeForm eventType={eventType} onSubmit={updateEventType} />
 
 const buildOptimisticResponse = eventType => ({
   __typename: 'Mutation',

--- a/app/javascript/pages/admin/EventTypes/index.js
+++ b/app/javascript/pages/admin/EventTypes/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
-import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
@@ -101,8 +100,8 @@ const tdProps = () => ({
   },
 })
 
-const EventTypes = ({ data: { networkStatus, eventTypes }, deleteEventType, togglePopover, destroyEventTypePopover }) =>
-  networkStatus === NetworkStatus.loading ? (
+const EventTypes = ({ data: { loading, eventTypes }, deleteEventType, togglePopover, destroyEventTypePopover }) =>
+  loading ? (
     <Loading />
   ) : (
     <div>
@@ -178,12 +177,9 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-    togglePopover,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  graphQLError,
+  togglePopover,
+})
 
 export default withActions(withData(EventTypes))

--- a/app/javascript/pages/admin/Events/edit.js
+++ b/app/javascript/pages/admin/Events/edit.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 
@@ -13,12 +12,8 @@ import EventQuery from './queries/show.gql'
 import UpdateEventMutation from './mutations/update.gql'
 import DestroySignupMutation from 'mutations/DestroySignupMutation.gql'
 
-const EditEvent = ({
-  data: { networkStatus, event, eventTypes, offices, organizations },
-  updateEvent,
-  destroySignup,
-}) =>
-  networkStatus === NetworkStatus.loading ? (
+const EditEvent = ({ data: { loading, event, eventTypes, offices, organizations }, updateEvent, destroySignup }) =>
+  loading ? (
     <Loading />
   ) : (
     <EventForm

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
-import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
@@ -119,8 +118,8 @@ const tdProps = () => ({
   },
 })
 
-const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
-  networkStatus === NetworkStatus.loading ? (
+const Events = ({ data: { loading, events }, deleteEvent }) =>
+  loading ? (
     <Loading />
   ) : (
     <div>

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
 import R from 'ramda'
-import { NetworkStatus } from 'apollo-client'
 import moment from 'moment'
 
 import { graphQLError } from 'actions'
@@ -30,8 +29,8 @@ const transformToReduxFormState = event => {
   }
 }
 
-const NewEvent = ({ createEvent, data: { networkStatus, event, eventTypes, offices, organizations } }) =>
-  networkStatus === NetworkStatus.loading ? (
+const NewEvent = ({ createEvent, data: { loading, event, eventTypes, offices, organizations } }) =>
+  loading ? (
     <Loading />
   ) : (
     <EventForm

--- a/app/javascript/pages/admin/IndividualEvents/index.js
+++ b/app/javascript/pages/admin/IndividualEvents/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { compose, graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import moment from 'moment'
 import R from 'ramda'
 import ReactTable from 'react-table'
@@ -90,8 +89,8 @@ class IndividualEvents extends React.Component {
 
   render() {
     const { data } = this.props
-    const { networkStatus, pendingIndividualEvents } = data
-    return networkStatus === NetworkStatus.loading ? (
+    const { loading, pendingIndividualEvents } = data
+    return loading ? (
       <Loading />
     ) : (
       <div className={s.eventsTable}>

--- a/app/javascript/pages/admin/Offices/edit.js
+++ b/app/javascript/pages/admin/Offices/edit.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 
@@ -12,8 +11,8 @@ import Loading from 'components/LoadingIcon'
 import OfficeQuery from './queries/show.gql'
 import UpdateOfficeMutation from './mutations/update.gql'
 
-const EditOffice = ({ data: { networkStatus, office }, updateOffice }) =>
-  networkStatus === NetworkStatus.loading ? <Loading /> : <OfficeForm office={office} onSubmit={updateOffice} />
+const EditOffice = ({ data: { loading, office }, updateOffice }) =>
+  loading ? <Loading /> : <OfficeForm office={office} onSubmit={updateOffice} />
 
 const buildOptimisticResponse = office => ({
   __typename: 'Mutation',

--- a/app/javascript/pages/admin/Offices/index.js
+++ b/app/javascript/pages/admin/Offices/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
-import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
@@ -106,8 +105,8 @@ const destroyActions = (togglePopover, destroyOfficePopover, deleteOffice) => [
   </button>,
 ]
 
-const Offices = ({ data: { networkStatus, offices }, deleteOffice, destroyOfficePopover, togglePopover }) =>
-  networkStatus === NetworkStatus.loading ? (
+const Offices = ({ data: { loading, offices }, deleteOffice, destroyOfficePopover, togglePopover }) =>
+  loading ? (
     <Loading />
   ) : (
     <div>
@@ -183,12 +182,9 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-    togglePopover,
-  }
-)
+const withActions = connect(mapStateToProps, {
+  graphQLError,
+  togglePopover,
+})
 
 export default withActions(withData(Offices))

--- a/app/javascript/pages/admin/Organizations/edit.js
+++ b/app/javascript/pages/admin/Organizations/edit.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 
@@ -12,12 +11,8 @@ import Loading from 'components/LoadingIcon'
 import OrganizationQuery from './queries/show.gql'
 import UpdateOrganizationMutation from './mutations/update.gql'
 
-const EditOrganization = ({ data: { networkStatus, organization }, updateOrganization }) =>
-  networkStatus === NetworkStatus.loading ? (
-    <Loading />
-  ) : (
-    <OrganizationForm organization={organization} onSubmit={updateOrganization} />
-  )
+const EditOrganization = ({ data: { loading, organization }, updateOrganization }) =>
+  loading ? <Loading /> : <OrganizationForm organization={organization} onSubmit={updateOrganization} />
 
 const buildOptimisticResponse = organization => ({
   __typename: 'Mutation',

--- a/app/javascript/pages/admin/Organizations/index.js
+++ b/app/javascript/pages/admin/Organizations/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
-import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
@@ -107,12 +106,12 @@ const tdProps = () => ({
 })
 
 const Organizations = ({
-  data: { networkStatus, organizations },
+  data: { loading, organizations },
   deleteOrganization,
   togglePopover,
   destroyOrganizationPopover,
 }) =>
-  networkStatus === NetworkStatus.loading ? (
+  loading ? (
     <Loading />
   ) : (
     <div>

--- a/app/javascript/pages/admin/Reporting/index.js
+++ b/app/javascript/pages/admin/Reporting/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import moment from 'moment'
 
@@ -19,13 +18,13 @@ const formatOrDefaultStartDate = filterValue => Number(moment(filterValue || def
 const formatOrDefaultEndDate = filterValue => Number(moment(filterValue || defaultEndDate).format('X'))
 
 const ReportingPage = ({
-  data: { networkStatus, users },
+  data: { loading, users },
   reportingStartDate,
   reportingEndDate,
   changeAdminReportingStart,
   changeAdminReportingEnd,
 }) =>
-  networkStatus === NetworkStatus.loading ? (
+  loading ? (
     <Loading />
   ) : (
     <div className={s.admin}>

--- a/app/javascript/pages/admin/Users/edit.js
+++ b/app/javascript/pages/admin/Users/edit.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
-import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import R from 'ramda'
 
@@ -12,12 +11,8 @@ import Loading from 'components/LoadingIcon'
 import UserQuery from './queries/show.gql'
 import UpdateUserMutation from './mutations/update.gql'
 
-const EditUser = ({ data: { networkStatus, user, offices }, updateUser }) =>
-  networkStatus === NetworkStatus.loading ? (
-    <Loading />
-  ) : (
-    <UserForm user={user} offices={offices} onSubmit={updateUser} />
-  )
+const EditUser = ({ data: { loading, user, offices }, updateUser }) =>
+  loading ? <Loading /> : <UserForm user={user} offices={offices} onSubmit={updateUser} />
 
 const buildOptimisticResponse = user => ({
   __typename: 'Mutation',

--- a/app/javascript/pages/admin/Users/index.js
+++ b/app/javascript/pages/admin/Users/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { connect } from 'react-redux'
-import { NetworkStatus } from 'apollo-client'
 import R from 'ramda'
 import ReactTable from 'react-table'
 import { Link } from 'react-router'
@@ -108,8 +107,8 @@ const tdProps = () => ({
   },
 })
 
-const Users = ({ data: { networkStatus, users }, deleteUser, togglePopover, destroyUserPopover }) =>
-  networkStatus === NetworkStatus.loading ? (
+const Users = ({ data: { loading, users }, deleteUser, togglePopover, destroyUserPopover }) =>
+  loading ? (
     <Loading />
   ) : (
     <div>


### PR DESCRIPTION
The current way of checking if Apollo Client is still loading, which relies on network status, is flawed. This PR proposes a fix.

## Description

We currently rely on network status provided by Apollo Client to check if it is still loading. For example, 

```javascript
if (networkStatus === NetworkStatus.loading) { ... }
```


This method is flawed. `NetworkStatus.loading` in Apollo Client has very specific meaning. Apollo Client has five "loading" statuses. Namely, `loading`, `setVariables`, `fetchMore`, `fetchMore`, and `poll`. See https://github.com/apollographql/apollo-client/blob/d8f5cb8d46cb30e49cebea7886ac99472b46ad59/packages/apollo-client/src/core/networkStatus.ts#L5-L10 for details.

The consequence is that sometimes page rendering is triggered when the data is not fully loaded, leading to null pointer errors on the frontend.

This PR proposes a fix that relies on the `loading` indicator, for proper loading status check.


## References
[Rollbar Exception](https://rollbar.com/zd-volunteer-portal/zd-volunteer-portal/items/7/)

## CCs

@zendesk/volunteer

## Risks (if any)
* [medium] - break page rendering due to incorrect loading check result
