### PR TITLE
Disable Apply button when no bulk action is selected

### DIFF
--- a/app/javascript/pages/admin/IndividualEvents/index.js
+++ b/app/javascript/pages/admin/IndividualEvents/index.js
@@ -112,6 +112,7 @@ class IndividualEvents extends React.Component {
           </select>
           <button
             className={s.bulkActionButton}
+            disabled={!this.state.bulkAction}
             onClick={() => {
               const { selected, bulkAction } = this.state
               if (selected.length <= 0) return

--- a/app/javascript/pages/admin/IndividualEvents/main.css
+++ b/app/javascript/pages/admin/IndividualEvents/main.css
@@ -195,3 +195,7 @@ textarea {
   height: 22px;
   line-height: 22px;
 }
+
+.bulkActionButton:disabled {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Description
Currently, admins can press the 'Apply' button even when no bulk action is selected. This will 'action' and remove all the selected events, and nothing will happen. To prevent confusion, we should just disable this button.

## References
Resolves https://github.com/zendesk/volunteer_portal/issues/169


## Screenshot

![image](https://user-images.githubusercontent.com/27116427/62993932-da68fd00-be9c-11e9-9a85-a38cedb8988b.png)


## CCs

## Risks (if any)
Low
