### PR TITLE
Enabling force_ssl in production staging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,9 @@ class ApplicationController < ActionController::Base
 
   def cors_preflight_check
     headers['Access-Control-Allow-Origin'] = if Rails.env.production?
-      'http://volunteer.zende.sk'
+      'https://volunteer.zende.sk'
     else
-      request.referer.include?('localhost') ? 'http://localhost:3000' : 'http://volunteer.zd-dev.com'
+      request.referer.include?('localhost') ? 'http://localhost:3000' : 'https://volunteer.zd-dev.com'
     end
 
     headers['Access-Control-Allow-Credentials'] = 'true'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Short description

## Description
enabling force_ssl configuration for production environment 
This means that browser will auto redirect  from http to https 

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/177)

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* [HIGH | medium | low] - low
