### PR TITLE
Fix deployments

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -5,6 +5,7 @@
 const webpack = require('webpack')
 const merge = require('webpack-merge')
 const CompressionPlugin = require('compression-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig, {
@@ -13,20 +14,15 @@ module.exports = merge(sharedConfig, {
   devtool: 'source-map',
   stats: 'normal',
 
+  optimization: {
+    minimizer: [
+      new UglifyJsPlugin({
+        sourceMap: true,
+      }),
+    ],
+  },
+
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      minimize: true,
-      sourceMap: true,
-
-      compress: {
-        warnings: false,
-      },
-
-      output: {
-        comments: false,
-      },
-    }),
-
     new CompressionPlugin({
       asset: '[path].gz[query]',
       algorithm: 'gzip',

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "react-test-renderer": "^15.6.0",
     "request": "^2.87.0",
     "style-loader": "^0.18.2",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9038,13 +9038,28 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
   integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
-uglify-js@^3.1.4:
+uglify-js@^3.1.4, uglify-js@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
   integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
+
+uglifyjs-webpack-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
+  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
+  dependencies:
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
+    is-wsl "^1.1.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    source-map "^0.6.1"
+    uglify-js "^3.6.0"
+    webpack-sources "^1.4.0"
+    worker-farm "^1.7.0"
 
 "uncontrollable@^3.3.1 || ^4.0.0":
   version "4.1.0"


### PR DESCRIPTION
Fix deployments by fixing `rake assets:precompile`.

## Description

#186 breaks `rake assets:precompile` and thus deployments. The error message is

```
       Running: rake assets:precompile
       Compiling…
       Compilation failed:
       /tmp/build_bc3c2bbee6511057884a6f7eac2bb693/node_modules/webpack-cli/bin/cli.js:93
       				throw err;
       				^
       
       Error: webpack.optimize.UglifyJsPlugin has been removed, please use config.optimization.minimize instead.
```

This PR proposes a fix by installing `uglifyjs-webpack-plugin` and updating the corresponding config. I've verified that `rake assets:precompile` works on my machine.

```
$ be rake assets:precompile
Compiling…
Compiled all packs in /Users/xli/Code/zendesk/volunteer_portal/public/assets/portal
(node:48426) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

## CCs

@zendesk/volunteer @craig-day 

## Risks (if any)
* low - deployments continue to be broken
