### PR TITLE
Update development readme to reference yarn instead of npm

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,8 @@
    ```bash
    gem install bundler
    bundle install
-   npm install
+   brew install yarn
+   yarn install
    ```
 
    `bundle install` might stop, prompting you to manually `gem install pg`. To proceed, do `brew install postgresql` first, followed by `gem install pg`, before continuing with `bundle install`.


### PR DESCRIPTION
As part of a webpack update we switched to using yarn, so the development docs needed updating to reflect this.

## CCs
@zendesk/volunteer

## Risks (if any)
Low
