### PR TITLE
Fix uncaught invariant violation console errors

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -49,7 +49,7 @@ const columns = deleteEvent => [
     accessor: 'startsAt',
     width: 130,
     sortable: true,
-    Cell: ({ value }) => moment(value).format('MMM DD, Y'),
+    Cell: ({ value }) => <span>{moment(value).format('MMM DD, Y')}</span>,
   },
   {
     id: 'duration',
@@ -207,8 +207,11 @@ function mapStateToProps(state, _ownProps) {
   }
 }
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(Events))


### PR DESCRIPTION
Fix uncaught invariant violation console errors in Events tab while in admin mode

## Description
When loading the Events tab as an admin, uncaught invariant violation console errors are emitted. This is due to the `Cell` delegate of the  `Start` column definition for ReactTable. 

The Cell delegate is required to return either a null or react element. However it was just returning a string. 

<img width="1119" alt="Screen Shot 2019-08-30 at 11 38 08 am" src="https://user-images.githubusercontent.com/3032977/63987894-22cf1e80-cb1d-11e9-83a6-5ce3629652c2.png">

## Implementation notes (if needed)
The fix was to wrap the string inside a span.

## CCs
@zendesk/volunteer
