### PR TITLE
Update admin user view

### DIFF
--- a/app/javascript/pages/admin/Users/edit.js
+++ b/app/javascript/pages/admin/Users/edit.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
-import R from 'ramda'
 
 import { graphQLError } from 'actions'
 
@@ -54,8 +53,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditUser))

--- a/app/javascript/pages/admin/Users/mutations/update.gql
+++ b/app/javascript/pages/admin/Users/mutations/update.gql
@@ -7,5 +7,6 @@ mutation updateUser($input: EditUserInputType!) {
     office {
       ...OfficeEntry
     }
+    isAdmin
   }
 }


### PR DESCRIPTION
## Description

Currently, after an user is promoted to admin, its status on admin's user management page is not updated until a full page refresh. This PR fixes it.

## CCs

@zendesk/volunteer @azaiszen 

## Risks
* low - just fetching a bit more data
