### PR TITLE
Update apollo cache with latest office data after user profile update

### DIFF
--- a/app/javascript/pages/admin/Users/mutations/update.gql
+++ b/app/javascript/pages/admin/Users/mutations/update.gql
@@ -1,7 +1,11 @@
 #import "fragments/UserEntry.gql"
+#import "fragments/OfficeEntry.gql"
 
 mutation updateUser($input: EditUserInputType!) {
   updateUser(input: $input) {
     ...UserEntry
+    office {
+      ...OfficeEntry
+    }
   }
 }


### PR DESCRIPTION
Update Apollo cache with latest office data after user profile update

## Description
When an admin updates the office of a user, the UI doesn't update to reflect the change.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/195)

## Implementation notes (if needed)
The mutation query for the profile update didn't include the office data. This meant that the Apollo cache was not updated and thus the UI didn't have the latest data to display it.

Added the`OfficeEntry` fragment to the update user mutation. This will tell Apollo to fetch this data after a successful update and update it's cache.

## Screenshots
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3032977/63991909-e73c5080-cb2c-11e9-86e0-d10919d69af9.gif"/>
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3032977/63991916-ec999b00-cb2c-11e9-88c1-32086447ed17.gif"/>
</details>

## CCs
@zendesk/volunteer

## Risks (if any)
Low
