### PR TITLE
Scope query with variables

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -173,10 +173,21 @@ const withData = compose(
         mutate({
           variables: { id: event.id },
           optimisticResponse: buildOptimisticResponse(event),
-          update: (proxy, { data: { deleteEvent } }) => {
-            const { events } = proxy.readQuery({ query: EventsQuery })
+          update: (cache, { data: { deleteEvent } }) => {
+            const queryVariables = {
+              officeId: ownProps.adminOfficeFilter.value || 'current',
+              sortBy: eventsSort,
+            }
+            const { currentUser, events } = cache.readQuery({
+              query: EventsQuery,
+              variables: queryVariables,
+            })
             const withEventRemoved = R.reject(event => event.id === deleteEvent.id, events)
-            proxy.writeQuery({ query: EventsQuery, data: { events: withEventRemoved } })
+            cache.writeQuery({
+              query: EventsQuery,
+              variables: queryVariables,
+              data: { currentUser, events: withEventRemoved },
+            })
           },
         }).catch(({ graphQLErrors }) => {
           ownProps.graphQLError(graphQLErrors)


### PR DESCRIPTION
Fix #190 

## Description
The cause of bug is, while the `EventsQuery` is scoped by variables [here](https://github.com/zendesk/volunteer_portal/blob/1267e1a49cee1253769335d0e80b2eb2754d2fad/app/javascript/pages/admin/Events/index.js#L162-L165), it is not scoped [here](https://github.com/zendesk/volunteer_portal/blob/1267e1a49cee1253769335d0e80b2eb2754d2fad/app/javascript/pages/admin/Events/index.js#L177). The bug is probably introduced in #39.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/190)

## Screenshots

![Kapture 2019-09-11 at 16 51 05](https://user-images.githubusercontent.com/1525352/64674605-89a4ee00-d4b4-11e9-863c-6a902034e7d1.gif)


## CCs

@zendesk/volunteer @ThuTrinh @kerrisim @adoragoh 

## Risks (if any)
* low - mess up Apollo cache
