### PR TITLE
Don't set defaultPageSize when showPagination=false

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -119,8 +119,9 @@ const tdProps = () => ({
   },
 })
 
-const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
-  networkStatus === NetworkStatus.loading ? (
+const Events = ({ data: { networkStatus, events }, deleteEvent }) => {
+  console.log(events)
+  return networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
     <div>
@@ -134,7 +135,6 @@ const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
         data={events}
         columns={columns(deleteEvent)}
         showPagination={false}
-        defaultPageSize={events.length}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}
@@ -147,6 +147,7 @@ const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
       />
     </div>
   )
+}
 
 const buildOptimisticResponse = event => ({
   __typename: 'Mutation',

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -119,9 +119,8 @@ const tdProps = () => ({
   },
 })
 
-const Events = ({ data: { networkStatus, events }, deleteEvent }) => {
-  console.log(events)
-  return networkStatus === NetworkStatus.loading ? (
+const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
+  networkStatus === NetworkStatus.loading ? (
     <Loading />
   ) : (
     <div>
@@ -147,7 +146,6 @@ const Events = ({ data: { networkStatus, events }, deleteEvent }) => {
       />
     </div>
   )
-}
 
 const buildOptimisticResponse = event => ({
   __typename: 'Mutation',


### PR DESCRIPTION
## Short description
Don't set defaultPageSize when showPagination=false

## Description
The ReactTable component was set with `showPagination={false}` and `defaultPageSize={events.length}`. 
This component seems to treat these two settings independently and so this combination caused the table to restrict the events shown to the first event list size, but not provide a way to view the next page.

This is a problem if the first list has a small number of events e.g. 0 or 1

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/206)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3032977/65567233-cedb1c80-df98-11e9-9f84-a2822b15ff80.gif">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3032977/65567244-d5699400-df98-11e9-9cc8-e5f306351fed.gif">
</details>

## CCs
@zendesk/volunteer 

## Risks (if any)
* low
