### PR TITLE
Fixed Apollo errors after creating a new event

### DIFF
--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -173,20 +173,22 @@ const withData = compose(
           variables: { id: event.id },
           optimisticResponse: buildOptimisticResponse(event),
           update: (cache, { data: { deleteEvent } }) => {
-            const queryVariables = {
-              officeId: ownProps.adminOfficeFilter.value || 'current',
-              sortBy: eventsSort,
-            }
-            const { currentUser, events } = cache.readQuery({
-              query: EventsQuery,
-              variables: queryVariables,
-            })
-            const withEventRemoved = R.reject(event => event.id === deleteEvent.id, events)
-            cache.writeQuery({
-              query: EventsQuery,
-              variables: queryVariables,
-              data: { currentUser, events: withEventRemoved },
-            })
+            try {
+              const queryVariables = {
+                officeId: ownProps.adminOfficeFilter.value || 'current',
+                sortBy: eventsSort,
+              }
+              const { currentUser, events } = cache.readQuery({
+                query: EventsQuery,
+                variables: queryVariables,
+              })
+              const withEventRemoved = R.reject(event => event.id === deleteEvent.id, events)
+              cache.writeQuery({
+                query: EventsQuery,
+                variables: queryVariables,
+                data: { currentUser, events: withEventRemoved },
+              })
+            } catch {}
           },
         }).catch(({ graphQLErrors }) => {
           ownProps.graphQLError(graphQLErrors)

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -174,19 +174,18 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(event),
           update: (cache, { data: { deleteEvent } }) => {
             try {
-              const queryVariables = {
-                officeId: ownProps.adminOfficeFilter.value || 'current',
-                sortBy: eventsSort,
+              const queryParams = {
+                query: EventsQuery,
+                variables: {
+                  officeId: ownProps.adminOfficeFilter.value || 'current',
+                  sortBy: eventsSort,
+                },
               }
-              const { currentUser, events } = cache.readQuery({
-                query: EventsQuery,
-                variables: queryVariables,
-              })
-              const withEventRemoved = R.reject(event => event.id === deleteEvent.id, events)
+              const data = cache.readQuery(queryParams)
+              const withEventRemoved = R.reject(event => event.id === deleteEvent.id, data.events)
               cache.writeQuery({
-                query: EventsQuery,
-                variables: queryVariables,
-                data: { currentUser, events: withEventRemoved },
+                ...queryParams,
+                data: { ...data, events: withEventRemoved },
               })
             } catch {}
           },

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -5,7 +5,7 @@ import R from 'ramda'
 import { NetworkStatus } from 'apollo-client'
 import moment from 'moment'
 
-import { graphQLError } from 'actions'
+import { graphQLError, changeAdminOfficeFilter } from 'actions'
 
 import EventForm from './form'
 
@@ -109,6 +109,7 @@ const withData = compose(
           },
         })
           .then(_response => {
+            ownProps.changeAdminOfficeFilter(event.office.id)
             ownProps.history.push('/portal/admin/events')
           })
           .catch(({ graphQLErrors }) => {
@@ -124,6 +125,7 @@ const withActions = connect(
   mapStateToProps,
   {
     graphQLError,
+    changeAdminOfficeFilter,
   }
 )
 

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -88,9 +88,11 @@ const withData = compose(
           variables: { input: event },
           optimisticResponse: buildOptimisticResponse(event),
           update: (proxy, { data: { createEvent } }) => {
-            const { events } = proxy.readQuery({ query: EventsQuery })
-            const withNewEvent = R.append(createEvent, events)
-            proxy.writeQuery({ query: EventsQuery, data: { events: withNewEvent } })
+            try {
+              const { events } = proxy.readQuery({ query: EventsQuery })
+              const withNewEvent = R.append(createEvent, events)
+              proxy.writeQuery({ query: EventsQuery, data: { events: withNewEvent } })
+            } catch {}
           },
         })
           .then(_response => {
@@ -105,8 +107,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(NewEvent))


### PR DESCRIPTION
## Description
1.  Apollo emits errors if you try to read a query that isn't in the cache (matches by query and variables)
- I wrapped the body of the update function in a try/catch block and swallowed the error. We don't really need to do anything if the query is not in the cache. 

2. Apollo needs the query variables to be set when reading and writing to the cache. These things make a unique reference to the query in the cache.
- Updated the code to specify the query variables in both read and write functions.

3. When creating a new event that is not for the current selected office you can't see it in the event list you are redirected towards.
- before redirecting I called the action to set the officeFilter to match that of the newly created event 

## References
None

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3032977/65584104-ba604980-dfc3-11e9-830f-ce30be8f8d89.gif">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3032977/65584279-fbf0f480-dfc3-11e9-8384-0d9706a40766.gif">
</details>

## CCs
@zendesk/volunteer 

## Risks (if any)
* Low
