### PR TITLE
Support creating directories for node versions below v10

### DIFF
--- a/config/locales/rosetta/rosetta-i18next-plugin.js
+++ b/config/locales/rosetta/rosetta-i18next-plugin.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
 
+const ASSETS_DIR = './public/assets/'
 const OUTPUT_DIR = './public/assets/locales/'
 
 const getJson = files => {
@@ -63,7 +64,8 @@ const compileBaseRosetta = (compilation, files) => {
 }
 
 const serveTranslationFiles = files => {
-  !fs.existsSync(OUTPUT_DIR) && fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+  !fs.existsSync(ASSETS_DIR) && fs.mkdirSync(ASSETS_DIR)
+  !fs.existsSync(OUTPUT_DIR) && fs.mkdirSync(OUTPUT_DIR)
   const jsonFileNames = getJson(files)
 
   jsonFileNames.forEach(jsonFileName => {


### PR DESCRIPTION
# Description
NodeJS version 10.12.0 has added a native support for both mkdir and mkdirSync to create a directory recursively with `recursive: true` option.

For users with node versions below, we'll need to do it this way.

## Risks (if any)
low
