### PR TITLE
Remove obsolete Zendesk widget embedding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,10 +7,6 @@
   <meta name="theme-color" content="#157878">
   <link rel="shortcut icon" type="image/png" href="/{{ site.github.repository_name }}/{{ site.favicon_file | 'assets/images/favicon.png' }}">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-
-  <!-- Start of volunteerhelp Zendesk Widget script -->
-  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3f0f2eea-7841-41a3-b638-d644b17174dd"> </script>
-  <!-- End of volunteerhelp Zendesk Widget script -->
 </head>
 
 <body>

--- a/public/404.html
+++ b/public/404.html
@@ -39,9 +39,4 @@
     <a href="/">Take me home</a>
   </div>
 </body>
-
-<!-- Start of volunteerhelp Zendesk Widget script -->
-<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3f0f2eea-7841-41a3-b638-d644b17174dd"> </script>
-<!-- End of volunteerhelp Zendesk Widget script -->
-
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -43,9 +43,4 @@
     <a href="/">Take me home</a>
   </div>
 </body>
-
-<!-- Start of volunteerhelp Zendesk Widget script -->
-<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3f0f2eea-7841-41a3-b638-d644b17174dd"> </script>
-<!-- End of volunteerhelp Zendesk Widget script -->
-
 </html>


### PR DESCRIPTION
## Description
Remove obsolete Zendesk widget embedding. The proper embedding is in `portal.html.erb`.
https://github.com/zendesk/volunteer_portal/blob/c45a938aa2840e7e178fc7b0ebfbd39ef0e2981d/app/views/layouts/portal.html.erb#L179-L181

## CCs

@zendesk/volunteer

## Risks (if any)
* low - break Zendesk widget by accident
