### PR TITLE
Refactor to be more idiomatic React

### DIFF
--- a/app/javascript/components/Calendar/index.js
+++ b/app/javascript/components/Calendar/index.js
@@ -42,7 +42,15 @@ const calendarComponents = (currentUser, offices, filters, filterActions, t) => 
   }
 
   return {
-    toolbar: R.partial(Toolbar, [offices, showFilter, eventFilter, officeFilter, t]),
+    toolbar: props => (
+      <Toolbar
+        {...props}
+        offices={offices}
+        showFilter={showFilter}
+        eventFilter={eventFilter}
+        officeFilter={officeFilter}
+      />
+    ),
     event: Event, // used by each view (Month, Day, Week)
   }
 }
@@ -63,7 +71,12 @@ const normalizeEvents = events =>
   )
 
 const applyShowFilter = dataAndFilters => {
-  const { event, currentUser, filters: { showFilter }, isValid } = dataAndFilters
+  const {
+    event,
+    currentUser,
+    filters: { showFilter },
+    isValid,
+  } = dataAndFilters
 
   if (isValid) {
     switch (showFilter.value) {
@@ -78,7 +91,12 @@ const applyShowFilter = dataAndFilters => {
 }
 
 const applyEventFilter = dataAndFilters => {
-  const { event, currentUser, filters: { eventFilter }, isValid } = dataAndFilters
+  const {
+    event,
+    currentUser,
+    filters: { eventFilter },
+    isValid,
+  } = dataAndFilters
 
   if (isValid) {
     switch (eventFilter.value) {
@@ -95,7 +113,12 @@ const applyEventFilter = dataAndFilters => {
 }
 
 const applyOfficeFilter = dataAndFilters => {
-  const { event, currentUser, filters: { officeFilter }, isValid } = dataAndFilters
+  const {
+    event,
+    currentUser,
+    filters: { officeFilter },
+    isValid,
+  } = dataAndFilters
 
   if (isValid) {
     switch (officeFilter.value) {
@@ -110,7 +133,11 @@ const applyOfficeFilter = dataAndFilters => {
 }
 
 const filterPipeline = ({ currentUser, filters, isValid }, event) =>
-  R.pipe(applyShowFilter, applyEventFilter, applyOfficeFilter)({
+  R.pipe(
+    applyShowFilter,
+    applyEventFilter,
+    applyOfficeFilter
+  )({
     event,
     currentUser,
     filters,
@@ -118,10 +145,11 @@ const filterPipeline = ({ currentUser, filters, isValid }, event) =>
   }).isValid
 
 const selectEvents = (events, currentUser, filters) =>
-  R.pipe(R.filter, R.values, normalizeEvents)(
-    R.partial(filterPipeline, [{ currentUser, filters, isValid: true }]),
-    events
-  )
+  R.pipe(
+    R.filter,
+    R.values,
+    normalizeEvents
+  )(R.partial(filterPipeline, [{ currentUser, filters, isValid: true }]), events)
 
 const Calendar = ({
   loading,

--- a/app/javascript/components/Toolbar/index.js
+++ b/app/javascript/components/Toolbar/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import R from 'ramda'
+import { withNamespaces } from 'react-i18next'
 
 import { navigate } from 'react-big-calendar/lib/utils/constants'
 
@@ -137,14 +137,18 @@ const toolbarTextMap = (t, key) => {
   return map[key]
 }
 
-const Toolbar = (
+const Toolbar = ({
+  label,
+  view,
+  views,
+  onNavigate,
+  onViewChange,
   offices,
   showFilter,
   eventFilter,
   officeFilter,
   t,
-  { label, view, views, onNavigate, onViewChange }
-) => (
+}) => (
   <div className={s.toolbar}>
     <div className={s.navBar}>
       <button className={s.todayBtn} type="button" onClick={() => onNavigate(navigate.TODAY)}>
@@ -184,4 +188,4 @@ const Toolbar = (
   </div>
 )
 
-export default Toolbar
+export default withNamespaces()(Toolbar)


### PR DESCRIPTION
- Components should comply with the `props => Component` interface
- Improve separation of concerns by keeping the i18next injection within the component and not force parent components to know about it.

## Description
I was talking to @samzx and we were brainstorming how to integrate i18n in away that doesn't couple all the components together.

This PR is an example of an alternative approach to passing the `t` prop explicitly from the top through to the children. 

The benefits here are that we can just wrap the components that need i18n with `withNamespaces` and the parent component doesn't need to know. This also means we end up touching only those files that need to change.

@zendesk/volunteer
