### PR TITLE
Fix Jest tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,17 +65,16 @@ jobs:
       - image: circleci/node:8-stretch-browsers
     steps:
       - checkout
-      # - restore_cache:
-      #     keys:
-      #       # when lock file changes, use increasingly general patterns to restore cache
-      #       - yarn-packages-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: yarn install
-      # - save_cache:
-      #     paths:
-      #       - ~/.cache/yarn
-      #     key: yarn-packages-v2-{{ checksum "yarn.lock" }}
+      - save_cache:
+          paths:
+            - ~/.cache/yarn
+          key: yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: run javascript tests
           command: yarn test -- --ci --runInBand --reporters=default --reporters=jest-junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,19 +67,18 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-js-dependencies-{{ checksum "yarn.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-js-dependencies-
+            # when lock file changes, use increasingly general patterns to restore cache
+            - yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
-          command: npm install
+          command: yarn install
       - save_cache:
           paths:
-            - ./node_modules
-          key: v1-js-dependencies-{{ checksum "yarn.lock" }}
+            - ~/.cache/yarn
+          key: yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: run javascript tests
-          command: npm test -- --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn test -- --ci --runInBand --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test_reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,17 +65,17 @@ jobs:
       - image: circleci/node:8-stretch-browsers
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            - yarn-packages-v2-{{ checksum "yarn.lock" }}
+      # - restore_cache:
+      #     keys:
+      #       # when lock file changes, use increasingly general patterns to restore cache
+      #       - yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: yarn install
-      - save_cache:
-          paths:
-            - ~/.cache/yarn
-          key: yarn-packages-v2-{{ checksum "yarn.lock" }}
+      # - save_cache:
+      #     paths:
+      #       - ~/.cache/yarn
+      #     key: yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: run javascript tests
           command: yarn test -- --ci --runInBand --reporters=default --reporters=jest-junit

--- a/app/javascript/components/OfficeForm/__snapshots__/test.js.snap
+++ b/app/javascript/components/OfficeForm/__snapshots__/test.js.snap
@@ -1572,6 +1572,11 @@ exports[`loads 1`] = `
             Asia/Qatar
           </option>
           <option
+            value="Asia/Qostanay"
+          >
+            Asia/Qostanay
+          </option>
+          <option
             value="Asia/Qyzylorda"
           >
             Asia/Qyzylorda

--- a/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
+++ b/app/javascript/components/OrganizationForm/__snapshots__/test.js.snap
@@ -96,7 +96,6 @@ exports[`loads 1`] = `
               onKeyDown={[Function]}
               onKeyPress={[Function]}
               placeholder="Search places"
-              style={Object {}}
               type="text"
               value=""
             />
@@ -106,7 +105,6 @@ exports[`loads 1`] = `
           >
             <ul
               className="geosuggest__suggests autocompleteList geosuggest__suggests--hidden"
-              style={Object {}}
             />
           </div>
         </div>


### PR DESCRIPTION
Update snapshots with new cached dependancies.
Previously, the jest tests would be passing on outdated node_modules that were cached incorrectly. We were check summing on the yarn file while using npm.