### PR TITLE
Jli/issue #230 replace replace table head for individual events table

### DIFF
--- a/app/javascript/pages/MyEvents/index.js
+++ b/app/javascript/pages/MyEvents/index.js
@@ -272,6 +272,10 @@ const IndividualEvents = props => {
 
   const { currentUser, offices, eventTypes, organizations } = data
 
+  const noIndividualEventsMessage = (
+    <p className={s.noEventsMessage}>Looks like there are no individual events here. Volunteer and record your first event.</p>
+  )
+
   const individualEventsColumns = [
     {
       id: 'description',
@@ -359,15 +363,20 @@ const IndividualEvents = props => {
         <h1>Individual Events</h1>
         <h4>Private events that you've attended and want to record.</h4>
       </div>
-      <ReactTable
-        NoDataComponent={() => null}
-        data={currentUser.individualEvents}
-        columns={individualEventsColumns}
-        showPagination={false}
-        pageSize={currentUser.individualEvents.length}
-        defaultSorted={[{ id: 'date', desc: true }]}
-        minRows={0}
-      />
+      {currentUser.individualEvents.length === 0 ? (
+        noIndividualEventsMessage
+      ) : (
+        <ReactTable
+          NoDataComponent={() => null}
+          data={currentUser.individualEvents}
+          columns={individualEventsColumns}
+          showPagination={false}
+          pageSize={currentUser.individualEvents.length}
+          defaultSorted={[{ id: 'date', desc: true }]}
+          minRows={0}
+        />
+      )}
+
       {popover && popover.type === 'editIndividualEvent' ? (
         <CreateEditDialog
           offices={offices}
@@ -423,21 +432,32 @@ const organizedEventsColumns = [
   },
 ]
 
-const OrganizedEvents = ({ currentUser: { signups } }) => (
-  <div className={s.eventsTable}>
-    <h1>Organized Events</h1>
-    <h4>Events organized by your organization, found on the calendar.</h4>
-    <ReactTable
-      NoDataComponent={() => null}
-      data={signups.map(signup => signup.event)}
-      columns={organizedEventsColumns}
-      showPagination={false}
-      pageSize={signups.length}
-      defaultSorted={[{ id: 'date', desc: true }]}
-      minRows={0}
-    />
-  </div>
-)
+const OrganizedEvents = ({ currentUser: { signups } }) => {
+  const noOrganizedEventsMessage = (
+    <p className={s.noEventsMessage}>
+      Looks like you haven't signed up to any organized events yet. Checkout the calendar to join your first event!
+    </p>
+  )
+  return (
+    <div className={s.eventsTable}>
+      <h1>Organized Events</h1>
+      <h4>Events organized by your organization, found on the calendar.</h4>
+      {signups.length === 0 ? (
+        noOrganizedEventsMessage
+      ) : (
+        <ReactTable
+          NoDataComponent={() => null}
+          data={signups.map(signup => signup.event)}
+          columns={organizedEventsColumns}
+          showPagination={false}
+          pageSize={signups.length}
+          defaultSorted={[{ id: 'date', desc: true }]}
+          minRows={0}
+        />
+      )}
+    </div>
+  )
+}
 
 const MyEvents = props => {
   const { data, locationBeforeTransitions } = props

--- a/app/javascript/pages/MyEvents/main.css
+++ b/app/javascript/pages/MyEvents/main.css
@@ -160,3 +160,7 @@ textarea {
 .eventsTable {
   margin-bottom: 20px;
 }
+
+.noEventsMessage {
+  font-style: italic;
+}


### PR DESCRIPTION
Short description

## Description
To show the user a clear message of the action to be taken when there is no events created or joined by replacing the table head by text instructions.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/230)

## Screenshots
<details>
<summary>Before</summary>
<img width="995" alt="Screen Shot 2019-10-23 at 1 29 36 pm" src="https://user-images.githubusercontent.com/42596493/67362185-372c1680-f5b6-11e9-90d5-72ffa665ee75.png">
</details>

<details>
<summary>After</summary>
<img width="733" alt="Screen Shot 2019-10-23 at 4 56 57 pm" src="https://user-images.githubusercontent.com/42596493/67362150-2a0f2780-f5b6-11e9-8a0e-a5a471148e01.png">
</details>

## CCs

@zendesk/volunteer 
