### PR TITLE
Fix missing calendar events for events in the same office

### DIFF
--- a/app/javascript/components/Calendar/index.js
+++ b/app/javascript/components/Calendar/index.js
@@ -95,13 +95,14 @@ const applyEventFilter = dataAndFilters => {
 const applyOfficeFilter = dataAndFilters => {
   const {
     event,
+    currentUser,
     filters: { officeFilter },
     isValid,
   } = dataAndFilters
   const showAll = officeFilter.value === 'all'
 
   if (isValid && !showAll) {
-    return R.merge(dataAndFilters, { isValid: event.office.id == officeFilter.value })
+    return R.merge(dataAndFilters, { isValid: event.office.id == (officeFilter.value || currentUser.office.id) })
   }
 
   return dataAndFilters


### PR DESCRIPTION
When the calendar is first loaded, events are filtered though the `applyOfficeFilter` code path.