### PR TITLE
Fix duplicate avatars when signing up

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,11 @@
 class Event < ApplicationRecord
   CALENDAR_TIME_FORMAT = '%Y%m%dT%H%M%SZ'.freeze
 
-  has_many :signups, -> { auto_include(false) }, dependent: :destroy, inverse_of: :event
+  # inverse_of on signups causes duplicate Avatars when signing up. Disable rubocop until cause is found
+  # rubocop:disable Rails/InverseOf
+  has_many :signups, -> { auto_include(false) }, dependent: :destroy
+  # rubocop:enable Rails/InverseOf
+
   # this custom association is to reduce data loaded and memory used when fetching users for an event
   has_many :signups_for_through, -> { select(:event_id, :user_id) }, class_name: 'Signup', inverse_of: :event
   has_many :users, through: :signups_for_through


### PR DESCRIPTION
## Description
This is a temporary fix. `inverse_by` was introduced in https://github.com/zendesk/volunteer_portal/commit/8ee7427c71ea3df350656b8b32bbb8156737c03f due to rubocop errors.
When `inverse_by` is on `signing` in `Events`, it causes three Avatars when signing up to an event. This fixes it for now but further investigation should happen to determine why this happens.
Fixes #45

## References
[Github Issue #224](https://github.com/zendesk/volunteer_portal/issues/224)

## Risks (if any)
* Low: fix bug, removing `inverse_of` unlikely to have terrible effects here
