### PR TITLE
Update api use of compress plugin based on upgrade from 1.0.0 to 3.0.0

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -24,7 +24,7 @@ module.exports = merge(sharedConfig, {
 
   plugins: [
     new CompressionPlugin({
-      asset: '[path].gz[query]',
+      filename: '[path].gz[query]',
       algorithm: 'gzip',
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf)$/,
     }),


### PR DESCRIPTION
Compilation seems to fail after the compression plugin upgrade #243 
```
rake assets:precompile
```

Returning error:
```
Compiling…
Compilation failed:
Compression Plugin Invalid Options

options should NOT have additional properties

ValidationError: Compression Plugin Invalid Options
    at validateOptions (/Users/sxie/Code/zendesk/volunteer_portal/node_modules/schema-utils/src/validateOptions.js:32:11)
    at new CompressionPlugin (/Users/sxie/Code/zendesk/volunteer_portal/node_modules/compression-webpack-plugin/dist/index.js:40:30)
    at Object.<anonymous> (/Users/sxie/Code/zendesk/volunteer_portal/config/webpack/production.js:26:5)
    at Module._compile (/Users/sxie/Code/zendesk/volunteer_portal/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (/Users/sxie/Code/zendesk/volunteer_portal/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
```

This is likely caused by breaking api change from 1.0.0 -> 3.0.0

New object used is  `filename` instead of `asset`
https://www.npmjs.com/package/compression-webpack-plugin
