### PR TITLE
Update pageSize based on number of users

### DIFF
--- a/app/javascript/components/Reporting/index.js
+++ b/app/javascript/components/Reporting/index.js
@@ -146,6 +146,7 @@ const Reporting = ({ users, startDate, endDate, onStartChange, onEndChange }) =>
     data={users}
     showPagination={false}
     defaultPageSize={users.length}
+    pageSize={users.length}
     minRows={0}
     defaultFilterMethod={defaultFilterMethod}
     getProps={containerProps}


### PR DESCRIPTION
Previously it doesn't update the size of the table if the number of users in the table change. This fixes that. For example, if there are 50 users loaded, the table will only show 50 users. If an admin changes the filters to "all" and there are say 100 users, still, only 50 users are shown.

Follow up:

- [ ]  Add a loading indicator to signal that it's fetching user data.


closes #248 