### PR TITLE
Revert portal name change

### DIFF
--- a/user_config.yml
+++ b/user_config.yml
@@ -1,1 +1,1 @@
-title: Social Impact Engagement Portal # Change this to your own name.
+title: Volunteer Portal # Change this to your own name.


### PR DESCRIPTION
Zendesk would like to revert this change back to the original for now, so let's do that.