### PR TITLE
Package upgrades get ready for React v16

### DIFF
--- a/app/javascript/components/App/__snapshots__/test.js.snap
+++ b/app/javascript/components/App/__snapshots__/test.js.snap
@@ -57,6 +57,7 @@ exports[`loads 1`] = `
           "iconSize": 24,
         },
       },
+      "borderRadius": 2,
       "bottomNavigation": Object {
         "backgroundColor": "#ffffff",
         "height": 56,
@@ -105,6 +106,7 @@ exports[`loads 1`] = `
         "calendarTextColor": "#555",
         "calendarYearBackgroundColor": "#ffffff",
         "color": "#333",
+        "headerColor": "#00bcd4",
         "selectColor": "#0097a7",
         "selectTextColor": "#ffffff",
         "textColor": "#ffffff",
@@ -401,6 +403,7 @@ exports[`loads 1`] = `
       },
       "tooltip": Object {
         "color": "#ffffff",
+        "opacity": 0.9,
         "rippleBackgroundColor": "#616161",
       },
       "userAgent": undefined,

--- a/app/javascript/pages/App/index.js
+++ b/app/javascript/pages/App/index.js
@@ -3,7 +3,6 @@ import R from 'ramda'
 import { compose, graphql } from 'react-apollo'
 import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 
 import App from 'components/App'
 
@@ -14,7 +13,6 @@ import UpdateUserOfficeMutation from './UpdateUserOfficeMutation.gql'
 
 class AppPage extends Component {
   constructor(props) {
-    injectTapEventPlugin()
     super(props)
   }
 
@@ -82,8 +80,11 @@ const withData = compose(
   })
 )
 
-const withActions = connect(mapStateToProps, {
-  togglePopover,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    togglePopover,
+  }
+)
 
 export default withActions(withData(AppPage))

--- a/app/javascript/pages/admin/Admin/index.js
+++ b/app/javascript/pages/admin/Admin/index.js
@@ -50,7 +50,7 @@ class Admin extends Component {
     } = this.props
 
     if (networkStatus !== NetworkStatus.loading && !currentUser.isAdmin) {
-      history.push('/portal')
+      router.push('/portal')
     }
   }
 

--- a/app/javascript/pages/admin/EventTypes/edit.js
+++ b/app/javascript/pages/admin/EventTypes/edit.js
@@ -41,7 +41,7 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(eventType),
         })
           .then(_response => {
-            ownProps.history.push('/portal/admin/event-types')
+            ownProps.router.push('/portal/admin/event-types')
           })
           .catch(({ graphQLErrors }) => {
             ownProps.graphQLError('eventType', graphQLErrors)
@@ -52,8 +52,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditEventType))

--- a/app/javascript/pages/admin/EventTypes/new.js
+++ b/app/javascript/pages/admin/EventTypes/new.js
@@ -34,7 +34,7 @@ const withData = graphql(CreateEventTypeMutation, {
         },
       })
         .then(_response => {
-          ownProps.history.push('/portal/admin/event-types')
+          ownProps.router.push('/portal/admin/event-types')
         })
         .catch(({ graphQLErrors }) => {
           ownProps.graphQLError(graphQLErrors)
@@ -44,8 +44,11 @@ const withData = graphql(CreateEventTypeMutation, {
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(NewEventType))

--- a/app/javascript/pages/admin/Events/edit.js
+++ b/app/javascript/pages/admin/Events/edit.js
@@ -63,10 +63,10 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(event),
         })
           .then(_response => {
-            ownProps.history.push('/portal/admin/events')
+            ownProps.router.push('/portal/admin/events')
           })
-          .catch(({ graphQLErrors }) => {
-            ownProps.graphQLError('event', graphQLErrors)
+          .catch(something => {
+            ownProps.graphQLError('event', something.graphQLErrors)
           }),
     }),
   }),
@@ -91,8 +91,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditEvent))

--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -110,10 +110,12 @@ const withData = compose(
         })
           .then(_response => {
             ownProps.changeAdminOfficeFilter(event.office.id)
-            ownProps.history.push('/portal/admin/events')
+            ownProps.router.push('/portal/admin/events')
           })
-          .catch(({ graphQLErrors }) => {
-            ownProps.graphQLError(graphQLErrors)
+          .catch(a => {
+            console.log('new', a)
+
+            ownProps.graphQLError(a.graphQLErrors)
           }),
     }),
   })

--- a/app/javascript/pages/admin/Offices/edit.js
+++ b/app/javascript/pages/admin/Offices/edit.js
@@ -37,7 +37,7 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(office),
         })
           .then(_response => {
-            ownProps.history.push('/portal/admin/offices')
+            ownProps.router.push('/portal/admin/offices')
           })
           .catch(({ graphQLErrors }) => {
             ownProps.graphQLError('office', graphQLErrors)
@@ -48,8 +48,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditOffice))

--- a/app/javascript/pages/admin/Offices/new.js
+++ b/app/javascript/pages/admin/Offices/new.js
@@ -36,7 +36,7 @@ const withData = graphql(CreateOfficeMutation, {
         },
       })
         .then(_response => {
-          ownProps.history.push('/portal/admin/offices')
+          ownProps.router.push('/portal/admin/offices')
         })
         .catch(({ graphQLErrors }) => {
           ownProps.graphQLError(graphQLErrors)
@@ -46,8 +46,11 @@ const withData = graphql(CreateOfficeMutation, {
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(NewOffice))

--- a/app/javascript/pages/admin/Organizations/edit.js
+++ b/app/javascript/pages/admin/Organizations/edit.js
@@ -41,7 +41,7 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(organization),
         })
           .then(_response => {
-            ownProps.history.push('/portal/admin/organizations')
+            ownProps.router.push('/portal/admin/organizations')
           })
           .catch(({ graphQLErrors }) => {
             ownProps.graphQLError('organization', graphQLErrors)
@@ -52,8 +52,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditOrganization))

--- a/app/javascript/pages/admin/Organizations/new.js
+++ b/app/javascript/pages/admin/Organizations/new.js
@@ -36,7 +36,7 @@ const withData = graphql(CreateOrganizationMutation, {
         },
       })
         .then(_response => {
-          ownProps.history.push('/portal/admin/organizations')
+          ownProps.router.push('/portal/admin/organizations')
         })
         .catch(({ graphQLErrors }) => {
           ownProps.graphQLError(graphQLErrors)
@@ -46,8 +46,11 @@ const withData = graphql(CreateOrganizationMutation, {
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(NewOrganization))

--- a/app/javascript/pages/admin/Users/edit.js
+++ b/app/javascript/pages/admin/Users/edit.js
@@ -41,7 +41,7 @@ const withData = compose(
           optimisticResponse: buildOptimisticResponse(user),
         })
           .then(_response => {
-            ownProps.history.push('/portal/admin/users')
+            ownProps.router.push('/portal/admin/users')
           })
           .catch(({ graphQLErrors }) => {
             ownProps.graphQLError('user', graphQLErrors)
@@ -53,8 +53,11 @@ const withData = compose(
 
 const mapStateToProps = (state, ownProps) => ({})
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(EditUser))

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ramda": "^0.23.0",
     "react": "^15.6.2",
     "react-apollo": "^2.0.4",
-    "react-big-calendar": "^0.12.3",
+    "react-big-calendar": "0.17.0",
     "react-dom": "^15.6.2",
     "react-geosuggest": "^2.7.0",
     "react-google-maps": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "react-router": "^3.2.5",
     "react-router-redux": "^4.0.5",
     "react-table": "^6.7.6",
-    "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.5.2",
     "redux-form": "^7.2.0",
     "redux-logger": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "path-complete-extname": "^0.1.0",
     "postcss-loader": "^2.0.10",
     "postcss-smart-import": "^0.7.6",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.7.2",
     "ramda": "^0.23.0",
     "react": "^15.6.2",
     "react-apollo": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "is-promise": "^2.1.0",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.13.1",
-    "material-ui": "^0.16.5",
+    "material-ui": "0.20.1",
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
     "normalizr": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-google-maps": "^4.11.0",
     "react-i18next": "^8.3.9",
     "react-redux": "^4.4.5",
-    "react-router": "^2.6.0",
+    "react-router": "^3.2.5",
     "react-router-redux": "^4.0.5",
     "react-table": "^6.7.6",
     "react-tap-event-plugin": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,11 +2723,6 @@ deep-diff@0.3.4:
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
   integrity sha1-qsXDmVIjar5fA3ojSQYLoBsArkg=
 
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
 deep-equal@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.0.tgz#3103cdf8ab6d32cf4a8df7865458f2b8d33f3745"
@@ -3985,15 +3980,15 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-history@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-2.1.2.tgz#4aa2de897a0e4867e4539843be6ecdb2986bfdec"
-  integrity sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=
+history@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
+  integrity sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=
   dependencies:
-    deep-equal "^1.0.0"
-    invariant "^2.0.0"
-    query-string "^3.0.0"
-    warning "^2.0.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4011,12 +4006,12 @@ hoist-non-react-statics@3.0.1:
   dependencies:
     react-is "^16.3.2"
 
-hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
   integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
-hoist-non-react-statics@^2.5.4:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -6991,11 +6986,12 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  integrity sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=
+query-string@^4.2.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
   dependencies:
+    object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
 querystring-es3@^0.2.0:
@@ -7223,15 +7219,18 @@ react-router-redux@^4.0.5:
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
   integrity sha1-InQDWWtRUeGCN32rg1tdRfD4BU4=
 
-react-router@^2.6.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-2.8.1.tgz#73e9491f6ceb316d0f779829081863e378ee4ed7"
-  integrity sha1-c+lJH2zrMW0Pd5gpCBhj43juTtc=
+react-router@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.5.tgz#6f5ce8f4f0b4ff6a6b2fc6106d7619e342fb57be"
+  integrity sha512-0/edMhPfOLRZ5IT3y6UkCpW7a13WrnGMR75ayAh2ZLynujEJOSptJt856GKnoCMW+7rk0/WYGUp/QaZNS9dTKg==
   dependencies:
-    history "^2.1.2"
-    hoist-non-react-statics "^1.2.0"
+    create-react-class "^15.5.1"
+    history "^3.0.0"
+    hoist-non-react-statics "^2.3.1"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
     warning "^3.0.0"
 
 react-table@^6.7.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,7 +3473,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7244,13 +7244,6 @@ react-table@^6.7.6:
   integrity sha512-s/mQLI1+mNvlae45MfAZyZ04YIT3jUzWJqx34s0tfwpDdgJkpeK6vyzwMUkKFCpGODBxpjBOekYZzcEmk+2FiQ==
   dependencies:
     classnames "^2.2.5"
-
-react-tap-event-plugin@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
-  integrity sha1-MWvrO8ZVbinshppyk+icgmqQdNI=
-  dependencies:
-    fbjs "^0.8.6"
 
 react-test-renderer@^15.6.0:
   version "15.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,7 +2903,7 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"dom-helpers@^2.3.0 || ^3.0.0", dom-helpers@^3.2.0:
+"dom-helpers@^2.3.0 || ^3.0.0", dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
@@ -6903,7 +6903,15 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
+prop-types-extra@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.0.tgz#32609910ea2dcf190366bacd3490d5a6412a605f"
+  integrity sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^3.0.0"
+
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7098,17 +7106,18 @@ react-apollo@^2.0.4:
     ts-invariant "^0.4.2"
     tslib "^1.9.3"
 
-react-big-calendar@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/react-big-calendar/-/react-big-calendar-0.12.3.tgz#3c795bc2f26baede696dd0132014804d4ee9acb0"
-  integrity sha1-PHlbwvJrrt5pbdATIBSATU7prLA=
+react-big-calendar@0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/react-big-calendar/-/react-big-calendar-0.17.0.tgz#2c3cb0a660bf2ee22610453cbf123a886ffae6f1"
+  integrity sha512-lE++ses5PFyx+tuGVkIM12LUZfhCOJaas3YVp0TKI4gJf+YpfiZb3Fi0qtKK87yxIDf9VvPTzBScoEyKv71wWw==
   dependencies:
     classnames "^2.1.3"
     date-arithmetic "^3.0.0"
     dom-helpers "^2.3.0 || ^3.0.0"
     invariant "^2.1.0"
     lodash "^4.17.4"
-    react-overlays "^0.6.0"
+    prop-types "^15.5.8"
+    react-overlays "^0.7.0"
     react-prop-types "^0.4.0"
     uncontrollable "^3.3.1 || ^4.0.0"
     warning "^2.0.0"
@@ -7175,14 +7184,15 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-overlays@^0.6.0:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.6.12.tgz#a079c750cc429d7db4c7474a95b4b54033e255c3"
-  integrity sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=
+react-overlays@^0.7.0:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.4.tgz#ef2ec652c3444ab8aa014262b18f662068e56d5c"
+  integrity sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==
   dependencies:
     classnames "^2.2.5"
-    dom-helpers "^3.2.0"
-    react-prop-types "^0.4.0"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
     warning "^3.0.0"
 
 react-prop-types-element-of-type@^2.1.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,6 +745,14 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@7.0.0-beta.42":
+  version "7.0.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
+  integrity sha512-iOGRzUoONLOtmCvjUsZv3mZzgCT6ljHQY5fr1qG1QIiJQwtM7zbPWGGpa3QWETq+UqwWyJnoi5XZDZRwZDFciQ==
+  dependencies:
+    core-js "^2.5.3"
+    regenerator-runtime "^0.11.1"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -1771,7 +1779,7 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-babel-runtime@^6.11.6, babel-runtime@^6.20.0, babel-runtime@^6.26.0:
+babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -1867,7 +1875,7 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bowser@^1.0.0:
+bowser@^1.7.3:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
   integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
@@ -2595,6 +2603,14 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
 
 css-loader@^3.2.0:
   version "3.2.0"
@@ -3457,7 +3473,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -4006,11 +4022,6 @@ hoist-non-react-statics@3.0.1:
   dependencies:
     react-is "^16.3.2"
 
-hoist-non-react-statics@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-  integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
-
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -4172,7 +4183,7 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-hyphenate-style-name@^1.0.1:
+hyphenate-style-name@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
@@ -4314,13 +4325,13 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inline-style-prefixer@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
-  integrity sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=
+inline-style-prefixer@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
+  integrity sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=
   dependencies:
-    bowser "^1.0.0"
-    hyphenate-style-name "^1.0.1"
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -5250,7 +5261,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keycode@^2.1.1:
+keycode@^2.1.8:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
   integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
@@ -5645,20 +5656,20 @@ marker-clusterer-plus@^2.1.4:
   resolved "https://registry.yarnpkg.com/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz#f8eff74d599dab3b7d0e3fed5264ea0e704f5d67"
   integrity sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc=
 
-material-ui@^0.16.5:
-  version "0.16.7"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.16.7.tgz#5ec5080d5f227817092c449105df9cbc8807941c"
-  integrity sha1-XsUIDV8ieBcJLESRBd+cvIgHlBw=
+material-ui@0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.20.1.tgz#a0f0f9f801be76a13cf3da9b319a1b97b28925c7"
+  integrity sha512-3EzMB3LWUONW0iETTGGSNOOw9NQWz5OmFJ7MbOJ0Y2zNOT2RFhYAXO/w3zs1fAxtXddl3MuqvYg9cW6ebooSUA==
   dependencies:
-    babel-runtime "^6.11.6"
-    inline-style-prefixer "^2.0.1"
-    keycode "^2.1.1"
+    babel-runtime "^6.23.0"
+    inline-style-prefixer "^3.0.8"
+    keycode "^2.1.8"
     lodash.merge "^4.6.0"
     lodash.throttle "^4.1.1"
-    react-addons-create-fragment "^15.0.0"
-    react-addons-transition-group "^15.0.0"
-    react-event-listener "^0.4.0"
-    recompose "^0.21.0"
+    prop-types "^15.5.7"
+    react-event-listener "^0.5.1"
+    react-transition-group "^1.2.1"
+    recompose "^0.26.0"
     simple-assign "^0.1.0"
     warning "^3.0.0"
 
@@ -6892,7 +6903,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7074,22 +7085,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-create-fragment@^15.0.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
-  integrity sha1-o5TefCx77Na1R1uhuXrEcs58dPg=
-  dependencies:
-    fbjs "^0.8.4"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.0"
-
-react-addons-transition-group@^15.0.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.6.2.tgz#8baebc2ae91ccdbf245fe29c9fd3d36f8b471923"
-  integrity sha1-i668Kukczb8kX+Kcn9PTb4tHGSM=
-  dependencies:
-    react-transition-group "^1.2.0"
-
 react-apollo@^2.0.4:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
@@ -7128,14 +7123,14 @@ react-dom@^15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-event-listener@^0.4.0:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.4.5.tgz#e3e895a0970cf14ee8f890113af68197abf3d0b1"
-  integrity sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=
+react-event-listener@^0.5.1:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.10.tgz#378403c555fe616f312891507a742ecbbe2c90de"
+  integrity sha512-YZklRszh9hq3WP3bdNLjFwJcTCVe7qyTf5+LWNaHfZQaZrptsefDK2B5HHpOsEEaMHvjllUPr0+qIFVTSsurow==
   dependencies:
-    babel-runtime "^6.20.0"
-    fbjs "^0.8.4"
-    prop-types "^15.5.4"
+    "@babel/runtime" "7.0.0-beta.42"
+    fbjs "^0.8.16"
+    prop-types "^15.6.0"
     warning "^3.0.0"
 
 react-geosuggest@^2.7.0:
@@ -7255,7 +7250,7 @@ react-test-renderer@^15.6.0:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-transition-group@^1.2.0:
+react-transition-group@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
   integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
@@ -7339,14 +7334,14 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-recompose@^0.21.0:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.21.2.tgz#ff3fbdb2397b1c77c47d451be2a63b9295d44681"
-  integrity sha1-/z+9sjl7HHfEfUUb4qY7kpXURoE=
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
+  integrity sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
-    hoist-non-react-statics "^1.0.0"
+    hoist-non-react-statics "^2.3.1"
     symbol-observable "^1.0.4"
 
 redux-form@^7.2.0:
@@ -7402,7 +7397,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==


### PR DESCRIPTION
## Description
- Get some packages in a version that allows for both React v15 and v16 in preparation for upgrading to React v16. This allows us to upgrade to React v16 (and its friends `react-dom` etc)  in a single PR without the other packages.
- This is going to be a multi-step process because some of these packages are so out of date (and React v16 has been out for so long) that the latest versions of those packages don't allow React v15. 
- This PR is to ensure we upgrade incrementally and don't put everything (and the code fixes for breaking changes) in one giant commit. 

- `react-google-maps` is still in a React v15 version because the version that is compatible with both v15 and v16 should be in its own PR due to the large amount of breaking changes. It is also a deprecated package and should be moved to something else. 

- The bump to `material-ui` has changed a few css variables that don't appear to have affected much. 

## References
[Github Issue # 235](https://github.com/zendesk/volunteer_portal/issues/235)

## Risks
* Medium: Chance that some of the packages have breaking changes that haven't been picked up. Needs to be thoroughly tested. 
