### PR TITLE
Add Pagination to react-tables

### DIFF
--- a/app/javascript/pages/MyEvents/index.js
+++ b/app/javascript/pages/MyEvents/index.js
@@ -273,7 +273,9 @@ const IndividualEvents = props => {
   const { currentUser, offices, eventTypes, organizations } = data
 
   const noIndividualEventsMessage = (
-    <p className={s.noEventsMessage}>Looks like there are no individual events here. Volunteer and record your first event.</p>
+    <p className={s.noEventsMessage}>
+      Looks like there are no individual events here. Volunteer and record your first event.
+    </p>
   )
 
   const individualEventsColumns = [
@@ -370,8 +372,7 @@ const IndividualEvents = props => {
           NoDataComponent={() => null}
           data={currentUser.individualEvents}
           columns={individualEventsColumns}
-          showPagination={false}
-          pageSize={currentUser.individualEvents.length}
+          defaultPageSize={10}
           defaultSorted={[{ id: 'date', desc: true }]}
           minRows={0}
         />
@@ -449,8 +450,7 @@ const OrganizedEvents = ({ currentUser: { signups } }) => {
           NoDataComponent={() => null}
           data={signups.map(signup => signup.event)}
           columns={organizedEventsColumns}
-          showPagination={false}
-          pageSize={signups.length}
+          defaultPageSize={10}
           defaultSorted={[{ id: 'date', desc: true }]}
           minRows={0}
         />

--- a/app/javascript/pages/admin/EventTypes/index.js
+++ b/app/javascript/pages/admin/EventTypes/index.js
@@ -115,8 +115,6 @@ const EventTypes = ({ data: { networkStatus, eventTypes }, deleteEventType, togg
         NoDataComponent={() => null}
         data={eventTypes}
         columns={columns(togglePopover)}
-        showPagination={false}
-        defaultPageSize={eventTypes.length}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}

--- a/app/javascript/pages/admin/Events/index.js
+++ b/app/javascript/pages/admin/Events/index.js
@@ -133,7 +133,6 @@ const Events = ({ data: { networkStatus, events }, deleteEvent }) =>
         NoDataComponent={() => null}
         data={events}
         columns={columns(deleteEvent)}
-        showPagination={false}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}
@@ -218,8 +217,11 @@ function mapStateToProps(state, _ownProps) {
   }
 }
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
 
 export default withActions(withData(Events))

--- a/app/javascript/pages/admin/Offices/index.js
+++ b/app/javascript/pages/admin/Offices/index.js
@@ -120,8 +120,6 @@ const Offices = ({ data: { networkStatus, offices }, deleteOffice, destroyOffice
         NoDataComponent={() => null}
         data={offices}
         columns={columns(togglePopover)}
-        showPagination={false}
-        defaultPageSize={offices.length}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}

--- a/app/javascript/pages/admin/Organizations/index.js
+++ b/app/javascript/pages/admin/Organizations/index.js
@@ -125,8 +125,6 @@ const Organizations = ({
         NoDataComponent={() => null}
         data={organizations}
         columns={columns(togglePopover)}
-        showPagination={false}
-        defaultPageSize={organizations.length}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}
@@ -191,9 +189,12 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-  togglePopover,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+    togglePopover,
+  }
+)
 
 export default withActions(withData(Organizations))

--- a/app/javascript/pages/admin/Users/index.js
+++ b/app/javascript/pages/admin/Users/index.js
@@ -117,8 +117,6 @@ const Users = ({ data: { networkStatus, users }, deleteUser, togglePopover, dest
         NoDataComponent={() => null}
         data={users}
         columns={columns(togglePopover)}
-        showPagination={false}
-        defaultPageSize={users.length}
         minRows={0}
         defaultFilterMethod={defaultFilterMethod}
         getProps={containerProps}
@@ -180,9 +178,12 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-const withActions = connect(mapStateToProps, {
-  graphQLError,
-  togglePopover,
-})
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+    togglePopover,
+  }
+)
 
 export default withActions(withData(Users))


### PR DESCRIPTION
## Description
Add pagination to the `react-tables` used in volunteer portal:
![image](https://user-images.githubusercontent.com/20157594/70110342-be36d900-16a2-11ea-8b86-8a5f99395bf8.png)

This is done to the following admin pages:
- admin/events
- admin/event-types
- admin/offices
- admin/organizations
- admin/users

admin/report and admin/individual-events have been excluded due to incompatibility with csv generation in reporting and the bulk actions on individual events.

This has also been implement in:
- portal/events (Individual Events and Organized Events)


## References
https://github.com/zendesk/volunteer_portal/issues/255
