### PR TITLE
Update webpacker binaries

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,6 +18,10 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
+  # Install JavaScript dependencies if using Yarn
+  # system('bin/yarn')
+
+
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
   #   cp 'config/database.yml.sample', 'config/database.yml'

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+VENDOR_PATH = File.expand_path('..', __dir__)
+Dir.chdir(VENDOR_PATH) do
+  begin
+    exec "yarnpkg #{ARGV.join(" ")}"
+  rescue Errno::ENOENT
+    $stderr.puts "Yarn executable was not detected in the system."
+    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    exit 1
+  end
+end


### PR DESCRIPTION
There's been some troubles with deploying to heroku for others:

![image](https://user-images.githubusercontent.com/27116427/70398417-459f9600-1a6f-11ea-8fef-fbd22f681920.png)

The main issue is with not detecting the NodeJS buildpack after bumping webpacker.

This PR _should_ fix this. I've tested it on a fresh heroku dyno.

cc @zendesk/volunteer 