### PR TITLE
Undo Dashboard leaderboard sorting

### DIFF
--- a/app/javascript/pages/Dashboard/index.js
+++ b/app/javascript/pages/Dashboard/index.js
@@ -117,9 +117,6 @@ const milestoneLabelStyling = (item, milestone, user) => {
   return R.join(' ', classes)
 }
 
-// TODO: remove; sorting should be done on server side
-const sortByHours = users => R.sort((a, b) => b.hours - a.hours)(users)
-
 const LeaderboardContainer = ({
   data: { networkStatus, volunteers, offices, currentUser },
   dashboardOfficeFilter,
@@ -137,7 +134,7 @@ const LeaderboardContainer = ({
           onChange={changeDashboardOfficeFilter}
         />
       </div>
-      {sortByHours(volunteers).map((user, i) => (
+      {volunteers.map((user, i) => (
         <div className={s.leaderboardUser} key={`user-${i}`}>
           <NamedAvatar image={user.photo} name={user.name} subtitle={user.group} />
           <span className={s.leaderboardHours}>{user.hours} hours</span>


### PR DESCRIPTION
Undo the sorting logic in the Dashboard leaderboard.

## Description
A sorting logic in the Dashboard leaderboard container was introduced to work around an issue with the backend returning the leaderboard in an incorrect order.

The backend issue was resolved in: https://github.com/zendesk/volunteer_portal/issues/53

This change will undo the sorting logic introduced in: https://github.com/zendesk/volunteer_portal/pull/81

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/70)

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* low - Should not have visible changes. Sorting may be incorrect if the data from the backend is wrong.
