### PR TITLE
Exclude css-module for @zendeskgarden scope

### DIFF
--- a/config/webpack/loaders/cssGarden.js
+++ b/config/webpack/loaders/cssGarden.js
@@ -7,11 +7,11 @@ module.exports = {
     {
       loader: 'css-loader',
       options: {
-        modules: true,
+        modules: false,
         importLoaders: 1,
       },
     },
     { loader: 'postcss-loader', options: { sourceMap: true } },
   ],
-  exclude: /react-big-calendar|react-table|@zendeskgarden/,
+  include: /@zendeskgarden/,
 }


### PR DESCRIPTION
The `modules` in the `css-loader` webpack plugin hashes the garden component classnames into those random strings. When you use garden components they have a specific class name like "im-a-tag". When you import `@zendeskgarden/react-tags/dist/styles.css` , everything get's hashed - so "im-a-tag" becomes "sdnKDSnd".

We can turn off the hashing for everything inside the garden path so they will work now :)

Thanks @kayison for guiding me to the solution 😀 