### PR TITLE
Run `db:migrate` on release (heroku)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
 webpacker: bundle exec ./bin/webpack-dev-server
+release: bundle exec rake db:migrate


### PR DESCRIPTION
This should also fix issues when the database changes. Admins won't need to do a manual database migration. 