### PR TITLE
Fix exception that causes event modal to not open

### DIFF
--- a/app/javascript/components/EventPopover/index.js
+++ b/app/javascript/components/EventPopover/index.js
@@ -38,8 +38,7 @@ const EventProperties = ({ event }) =>
   event ? (
     <div>
       <p className={s.description}>
-        <span className={s.eventTitle}>{event.title}</span>
-        <span className={s.eventType}>{event.eventType.title || 'General'}:</span>
+        <span className={s.eventType}>{event.eventType ? event.eventType.title : 'General'}</span>
         {renderEventDescription(event)}
       </p>
       <EventLocation event={event} />


### PR DESCRIPTION
## Description
When clicking on event the modal doesn't open anymore and this exception is visible in the console

<img width="923" alt="Screenshot 2020-01-07 at 14 29 57" src="https://user-images.githubusercontent.com/630796/71902601-53be0080-315a-11ea-9c53-c72ee86ff8e4.png">

The source-map point at the point in the code where we try to access the property `title` on an undefined `eventType`.
Please let me know if this change makes any sense :)

## References
[Slack thread](https://zendesk.slack.com/archives/C2R7UHJCX/p1578404726005800)
https://github.com/zendesk/volunteer_portal/issues/284

## Tasks (if needed)
- [ ] Write tests

## CCs

@zendesk/volunteer

## Risks (if any)
* [low] - visual frontend change
