### PR TITLE
Update docs with new app start command

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -25,6 +25,7 @@ The volunteer portal is made of 2 applications. A ReactJS web client and a Ruby 
    ```bash
    gem install bundler
    bundle install
+   brew install heroku
    brew install yarn
    yarn install
    ```
@@ -99,10 +100,10 @@ Make sure that PostgreSQL is running.
    ./script/setup_db.sh
    ```
 
-To start the app and run it locally, run the command line blow. `foreman` is used to run both the rails server and the webpack dev server in development.
+To start the app and run it locally, run the command line blow. `heroku` is used to run both the rails server and the webpack dev server in development. It will run the processes listed in the `Procfile`
 
 ```
-bundle exec foreman start
+bundle exec heroku local
 ```
 
 The server runs on [localhost:5000](http://localhost:5000/) by default.


### PR DESCRIPTION
## Description
`bundle exec foreman start` exits due to the newly added release process. This process should only run during deployment to heroku. Foreman doesn't seem to understand this. Instead, we should run `bundle exec keroku local`.

## References
[Github Issue](https://github.com/codetriage/codetriage/issues/485)

## Screenshots

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3032977/72027894-bcc98380-32d4-11ea-9829-537c9aba20e5.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3032977/72027889-b935fc80-32d4-11ea-878e-63feecb0f6f8.png">
</details>

## CCs
@zendesk/volunteer

## Risks (if any)
* [low] - already broken, local env only.
