### PR TITLE
Add soft delete to event types

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,4 +3,3 @@ GOOGLE_CLIENT_ID=test
 GOOGLE_CLIENT_SECRET=test123
 ATTR_ENCRYPTION_KEY=testkey
 PUBLIC_ASSET_HOST=localhost
-DATABASE_URL=postgres://volunteer@localhost/volunteer_test

--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ GOOGLE_CLIENT_ID=test
 GOOGLE_CLIENT_SECRET=test123
 ATTR_ENCRYPTION_KEY=testkey
 PUBLIC_ASSET_HOST=localhost
+DATABASE_URL=postgres://volunteer@localhost/volunteer_test

--- a/app/graphql/mutations/delete_individual_event.rb
+++ b/app/graphql/mutations/delete_individual_event.rb
@@ -7,8 +7,9 @@ module Mutations
     argument :input, Types::Input::DeleteIndividualEventInputType, required: true
 
     def resolve(input:)
-      individualEvent = IndividualEvent.find(args[:id])
-      individualEvent.soft_delete!(validate: false)
+      IndividualEvent
+        .find(input.id)
+        .soft_delete!(validate: false)
       context[:current_user]
     end
   end

--- a/app/graphql/mutations/delete_individual_event.rb
+++ b/app/graphql/mutations/delete_individual_event.rb
@@ -7,7 +7,8 @@ module Mutations
     argument :input, Types::Input::DeleteIndividualEventInputType, required: true
 
     def resolve(input:)
-      IndividualEvent.destroy(input.id)
+      individualEvent = IndividualEvent.find(args[:id])
+      individualEvent.soft_delete!(validate: false)
       context[:current_user]
     end
   end

--- a/app/graphql/resolvers/event_type_resolver.rb
+++ b/app/graphql/resolvers/event_type_resolver.rb
@@ -1,5 +1,12 @@
 module EventTypeResolver
   class << self
+    def all()
+      EventType
+      .all
+      .where(deleted_at: nil)
+      .order(:title)
+    end
+
     def create(_, args, _context)
       event_type = EventType.new
       event_type.title = args[:input].title
@@ -18,7 +25,7 @@ module EventTypeResolver
 
     def delete(_, args, _context)
       event_type = EventType.find(args[:id])
-      event_type.destroy!
+      event_type.soft_delete!(validate: false)
 
       event_type
     end

--- a/app/graphql/resolvers/event_type_resolver.rb
+++ b/app/graphql/resolvers/event_type_resolver.rb
@@ -1,10 +1,10 @@
 module EventTypeResolver
   class << self
-    def all()
+    def all
       EventType
-      .all
-      .where(deleted_at: nil)
-      .order(:title)
+        .all
+        .where(deleted_at: nil)
+        .order(:title)
     end
 
     def create(_, args, _context)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -80,7 +80,7 @@ module Types
 
     field :event_types, [EventTypeGraphType], null: true
     def event_types
-      EventType.all
+      EventTypeResolver.all
     end
 
     field :roles, [RoleGraphType], null: true

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,4 +1,5 @@
 class EventType < ApplicationRecord
+  has_soft_deletion default_scope: false
   has_many :events, dependent: :nullify
 
   validates :title, presence: true

--- a/db/migrate/20200109032527_add_soft_delete_to_event_types.rb
+++ b/db/migrate/20200109032527_add_soft_delete_to_event_types.rb
@@ -1,0 +1,5 @@
+class AddSoftDeleteToEventTypes < ActiveRecord::Migration[5.1]
+  def change
+    add_column :event_types, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191218033609) do
+ActiveRecord::Schema.define(version: 20200109032527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20191218033609) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["updated_at"], name: "index_event_types_on_updated_at"
   end
 

--- a/test/fixtures/event_types.yml
+++ b/test/fixtures/event_types.yml
@@ -11,3 +11,7 @@ individual:
 
 group:
   title: Group
+
+group:
+  title: Grab Hunting
+  deleted_at: 2020-01-01 11:38:03

--- a/test/graphql/resolvers/event_type_resolver_test.rb
+++ b/test/graphql/resolvers/event_type_resolver_test.rb
@@ -34,9 +34,9 @@ describe EventTypeResolver do
     it 'deletes the given event type' do
       EventTypeResolver.delete(nil, { id: event_type.id }, nil)
 
-      e = EventType.where(id: event_type.id)
+      e = EventType.find(event_type.id)
 
-      assert_empty e
+      assert_not_nil e.deleted_at
     end
   end
 end

--- a/test/graphql/resolvers/event_type_resolver_test.rb
+++ b/test/graphql/resolvers/event_type_resolver_test.rb
@@ -3,6 +3,20 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe EventTypeResolver do
+  describe '.all' do
+    it 'only return active event_types in alphabetical order' do
+      EventType.delete_all
+      deleted_at = Time.zone.local(2020, 1, 1, 1, 0)
+      event1 = EventType.create!(title: 'test1')
+      event3 = EventType.create!(title: 'test3')
+      event2 = EventType.create!(title: 'test2')
+      EventType.create!(title: 'test4', deleted_at: deleted_at)
+
+      all_events = EventTypeResolver.all
+      assert_equal [event1, event2, event3], all_events
+    end
+  end
+
   describe '.create' do
     it 'creates a new event type' do
       input = stub(title: 'Test Type')


### PR DESCRIPTION
## Description
When an `event_type` is deleted, the record persists in the db with a `deleted_at` timestamp. 
Existing associated records will still be able to access the deleted `event_type`. 
However these deleted event types will be excluded when queried for in a list (controlled at the graph resolver end).

Also fixed an issue where `individual_events` weren't being soft deleted properly. They were being destroyed.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/287)

## Implementation notes
soft deletion is achieved through the [soft delete gem](https://github.com/grosser/soft_deletion). Normally the `default_scope` is set as true in order to exclude deleted records from queries. However in our case, we actually want this data available to previous associations and only exclude them when queried for in a list. To achieve this, the `default_scope` is set as false and the filtering is managed on the graph resolver end.

app/models/event_type.rb
```ruby
class EventType < ApplicationRecord
  has_soft_deletion default_scope: false
  has_many :events, dependent: :nullify

  validates :title, presence: true
end
```
app/graphql/resolvers/event_type_resolver.rb
```ruby
module EventTypeResolver
  class << self
    def all()
      EventType
      .all
      .where(deleted_at: nil)
      .order(:title)
    end
    ...
  end
end

```

### Edge Cases
When editing events/individual events that associate to a deleted event_type, the `event_type` dropdown field will appear unset. The user will need to choose a new active `event_type`. This is by design.

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* [low] - this change is additive
