### PR TITLE
Add soft delete to events

### DIFF
--- a/app/graphql/resolvers/event_resolver.rb
+++ b/app/graphql/resolvers/event_resolver.rb
@@ -13,7 +13,7 @@ module EventResolver
                     args[:office_id]
                   end
 
-      events = Event.all
+      events = Event.where(deleted_at: nil)
       events = events.for_office(office_id) if office_id
       events = events.before(Time.zone.at(args[:before])) if args[:before]
       events = events.after(Time.zone.at(args[:after]))   if args[:after]
@@ -46,7 +46,7 @@ module EventResolver
 
     def delete(_, args, _context)
       event = Event.find(args[:id])
-      event.destroy!
+      event.soft_delete!
 
       event
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   CALENDAR_TIME_FORMAT = '%Y%m%dT%H%M%SZ'.freeze
+  has_soft_deletion default_scope: false
 
   # inverse_of on signups causes duplicate Avatars when signing up. Disable rubocop until cause is found
   # rubocop:disable Rails/InverseOf

--- a/db/migrate/20200110020955_add_soft_delete_to_events.rb
+++ b/db/migrate/20200110020955_add_soft_delete_to_events.rb
@@ -1,0 +1,5 @@
+class AddSoftDeleteToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200109032527) do
+ActiveRecord::Schema.define(version: 20200110020955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20200109032527) do
     t.integer "event_group_id"
     t.datetime "starts_at"
     t.datetime "ends_at"
+    t.datetime "deleted_at"
     t.index ["event_type_id"], name: "index_events_on_event_type_id"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["updated_at"], name: "index_events_on_updated_at"

--- a/test/graphql/resolvers/event_type_resolver_test.rb
+++ b/test/graphql/resolvers/event_type_resolver_test.rb
@@ -25,6 +25,7 @@ describe EventTypeResolver do
 
       e = EventType.last
 
+      assert_nil e.deleted_at
       assert_equal 'Test Type', e.title
     end
   end


### PR DESCRIPTION
We want to retain the deleted event data in order to retain the associated historic signup information.

## Description
Previously viewing the `My Events` list would fail if any associated events were deleted. This is because the associated signups weren't being deleted in some cases. However after some discussion it was decided that we would soft delete instead in order to preserve data for auditing purposes.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/254)

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* [low] - we are already loosing data.
