### PR TITLE
Cleanup unused tables from DB

### DIFF
--- a/db/migrate/20200110031714_drop_volunteers.rb
+++ b/db/migrate/20200110031714_drop_volunteers.rb
@@ -1,0 +1,22 @@
+class DropVolunteers < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :events_volunteers, name: 'by_event_and_volunteer'
+    drop_table :events_volunteers
+    drop_table :volunteers
+  end
+
+  def down
+    create_table :volunteers do |t|
+      t.text :name
+      t.text :email
+      t.timestamps
+    end
+
+    create_table :events_volunteers, id: false do |t|
+      t.belongs_to :event
+      t.belongs_to :volunteer
+      t.timestamps
+    end
+    add_index :events_volunteers, [:event_id, :volunteer_id], unique: true, name: 'by_event_and_volunteer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200110020955) do
+ActiveRecord::Schema.define(version: 20200110031714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,12 +58,6 @@ ActiveRecord::Schema.define(version: 20200110020955) do
     t.index ["event_type_id"], name: "index_events_on_event_type_id"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["updated_at"], name: "index_events_on_updated_at"
-  end
-
-  create_table "events_volunteers", id: false, force: :cascade do |t|
-    t.integer "event_id"
-    t.integer "volunteer_id"
-    t.index ["event_id", "volunteer_id"], name: "by_event_and_volunteer", unique: true
   end
 
   create_table "individual_event_tags", force: :cascade do |t|
@@ -176,18 +170,6 @@ ActiveRecord::Schema.define(version: 20200110020955) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
     t.index ["updated_at"], name: "index_users_on_updated_at"
-  end
-
-  create_table "volunteers", id: :serial, force: :cascade do |t|
-    t.text "name"
-    t.text "email"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "photo"
-    t.string "management_level"
-    t.string "team"
-    t.string "interest"
-    t.string "locale"
   end
 
   add_foreign_key "event_tags", "events"


### PR DESCRIPTION
I did a scan of the codebase and I am pretty sure the `volunteers` and `events_volunteers` tables are not being used at all. Looking at the git history, it looks like they were created early on. I suspect things got complicated and a decision was made to use the users and signup tables instead.

I have also check these tables in production, they are empty. So I reckon it is pretty safe to remove them and mitigate confusion in the future.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/254)

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* [low] - There is no data to lose and the migration script has a rollback
