### PR TITLE
Ignore unapproved individual event hours

### DIFF
--- a/app/graphql/resolvers/volunteer_resolver.rb
+++ b/app/graphql/resolvers/volunteer_resolver.rb
@@ -12,7 +12,10 @@ module VolunteerResolver
       user_entry = '"users"."id", "users"."first_name", "users"."last_name", "users"."email", "users"."group", "users"."photo"'
 
       events_scope = User.joins(:events).select("#{user_entry}, \"events\".\"duration\"")
-      individual_events_scope = User.joins(:individual_events).select("#{user_entry}, \"individual_events\".\"duration\"")
+      individual_events_scope = User
+                                .joins(:individual_events)
+                                .merge(IndividualEvent.approved)
+                                .select("#{user_entry}, \"individual_events\".\"duration\"")
 
       office_id = case args[:office_id]
                   when 'all'

--- a/test/graphql/resolvers/volunteer_resolver_test.rb
+++ b/test/graphql/resolvers/volunteer_resolver_test.rb
@@ -152,6 +152,19 @@ describe VolunteerResolver do
     let(:individual_event1) { individual_events(:approved) }
     let(:individual_event2) { individual_events(:minimum) }
 
+    describe 'when user has unapproved individual events' do
+      it 'does not count unapproved hours' do
+        args = {}
+        duration = 10
+
+        individual_event1.update(duration: duration, user: user2) # approved
+        individual_event2.update(duration: duration, user: user2) # unapproved
+        results = VolunteerResolver.all(nil, args, nil).find_by(id: user2).duration
+
+        results.must_equal duration
+      end
+    end
+
     describe 'when user only has individual events' do
       it 'returns the correct duration' do
         args = {}
@@ -171,7 +184,7 @@ describe VolunteerResolver do
 
         event1.update(ends_at: event1.starts_at + duration.minutes)
         individual_event1.update(duration: duration)
-        individual_event2.update(duration: duration)
+        individual_event2.update(duration: duration, status: IndividualEvent::APPROVED)
         results = VolunteerResolver.all(nil, args, nil).to_a.first.duration
 
         results.must_equal duration * 3


### PR DESCRIPTION
Ignore unapproved individual event hours in Dashboard Top Volunteers

## Description
The new VolunteerResolver did not take into account the approval status of individual events. This caused the Dashboard to show volunteers with many unapproved individual event hours, which manifests as an unsorted dashboard.

This change will make VolunteerResolver count only the approved individual events as it should be.

## References
N/A

## CCs

If app migration related
@zendesk/volunteer @zendesk/mel-volunteer 

## Risks (if any)
* low - no impact expected but could have unforeseen risks