### PR TITLE
Remove debugging console.log

### DIFF
--- a/app/javascript/pages/admin/Events/new.js
+++ b/app/javascript/pages/admin/Events/new.js
@@ -115,10 +115,8 @@ const withData = compose(
             ownProps.changeAdminOfficeFilter(event.office.id)
             ownProps.router.push('/portal/admin/events')
           })
-          .catch(a => {
-            console.log('new', a)
-
-            ownProps.graphQLError(a.graphQLErrors)
+          .catch(response => {
+            ownProps.graphQLError(response.graphQLErrors)
           }),
     }),
   })


### PR DESCRIPTION
## Description
This console.log was accidentally left in from debugging, so it is removed.

## Risks (if any)
*  Low: only console.log removal
