### PR TITLE
admin can add volunteers manually on Event edit page

### DIFF
--- a/app/graphql/mutations/create_signup.rb
+++ b/app/graphql/mutations/create_signup.rb
@@ -5,10 +5,12 @@ module Mutations
     null true
 
     argument :event_id, ID, required: true
+    argument :user_email, String, required: false
 
-    def resolve(event_id:)
+    def resolve(event_id:, user_email: nil)
       event = Event.find(event_id)
-      event.sign_up_user!(context[:current_user])
+      user = user_email.present? ? User.where(email: user_email).first : context[:current_user]
+      event.sign_up_user!(user) if user
       event.save!
       event.signups.last
     end

--- a/app/javascript/components/EventForm/index.js
+++ b/app/javascript/components/EventForm/index.js
@@ -63,12 +63,21 @@ const renderFieldHelper = ({ input, type, label, className, selectOptions }) => 
 const renderError = error => <span className={s.fieldError}>{error}</span>
 
 const renderField = props => {
-  const { input, label, type, Custom, meta: { touched, error, warning }, className, required } = props
+  const {
+    input,
+    label,
+    type,
+    Custom,
+    meta: { touched, error, warning },
+    className,
+    optional,
+  } = props
   const fieldInput = renderFieldHelper({ input, type, label, className, selectOptions: props.children })
   return (
     <div>
       <label className={s.label}>
-        {label} <span className={s.errorMsg}>{touched && error ? renderError(error) : '*'}</span>
+        {label}{' '}
+        <span className={s.errorMsg}>{touched && error ? renderError(error) : optional === 'true' ? '' : '*'}</span>
       </label>
       <div>{Custom ? <Custom {...props} /> : fieldInput}</div>
     </div>
@@ -144,94 +153,117 @@ const EventForm = ({
   organizations,
   offices,
   users,
+  createSignup,
   destroySignup,
-}) => (
-  <form className={s.form} onSubmit={handleSubmit}>
-    {isNoErrors(errors) ? null : <Callout type="error" message={formatGraphQLErrors(errors)} />}
-    <div className={s.inputGroup}>
-      <Field label="Title" className={s.field} name="title" component={renderField} type="text" />
-    </div>
-    <div className={s.inputGroup}>
-      <Field label="Description" className={s.field} name="description" component={renderField} type="textarea" />
-    </div>
-    <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
-      <div className={s.column}>
-        <Field label="Event Type" className={s.field} name="eventType.id" component={renderField} type="select">
-          <option value="-" key="-" />
-          {R.map(
-            eventType => (
-              <option value={eventType.id} key={`eventType-${eventType.id}`}>
-                {eventType.title}
-              </option>
-            ),
-            eventTypes
-          )}
-        </Field>
+}) => {
+  return (
+    <form className={s.form} onSubmit={handleSubmit}>
+      {isNoErrors(errors) ? null : <Callout type="error" message={formatGraphQLErrors(errors)} />}
+      <div className={s.inputGroup}>
+        <Field label="Title" className={s.field} name="title" component={renderField} type="text" />
       </div>
-      <div className={s.column}>
+      <div className={s.inputGroup}>
+        <Field label="Description" className={s.field} name="description" component={renderField} type="textarea" />
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
+        <div className={s.column}>
+          <Field label="Event Type" className={s.field} name="eventType.id" component={renderField} type="select">
+            <option value="-" key="-" />
+            {R.map(
+              eventType => (
+                <option value={eventType.id} key={`eventType-${eventType.id}`}>
+                  {eventType.title}
+                </option>
+              ),
+              eventTypes
+            )}
+          </Field>
+        </div>
+        <div className={s.column}>
+          <Field
+            label="Organization"
+            className={s.field}
+            name="organization.id"
+            component={renderField}
+            organizations={organizations}
+            Custom={OrganizationField}
+          />
+        </div>
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
+        <div className={s.column}>
+          <Field label="Office" className={s.field} name="office.id" component={renderField} type="select">
+            <option value="-" key="-" />
+            {R.map(
+              office => (
+                <option value={office.id} key={`office-${office.id}`}>
+                  {office.name}
+                </option>
+              ),
+              offices
+            )}
+          </Field>
+        </div>
+        <div className={s.column}>
+          <Field label="Location" className={s.field} name="location" component={renderField} Custom={LocationField} />
+        </div>
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
+        <div className={s.column}>
+          <Field label="Start Date" className={s.field} name="startsAt" component={renderField} Custom={DateField} />
+        </div>
+        <div className={s.column}>
+          <Field label="Start Time" className={s.field} name="startsAt" component={renderField} Custom={TimeField} />
+        </div>
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
+        <div className={s.column}>
+          <Field label="End Date" className={s.field} name="endsAt" component={renderField} Custom={DateField} />
+        </div>
+        <div className={s.column}>
+          <Field label="End Time" className={s.field} name="endsAt" component={renderField} Custom={TimeField} />
+        </div>
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
+        <div className={s.column}>
+          <Field
+            label="Capacity"
+            className={s.field}
+            name="capacity"
+            component={renderField}
+            type="number"
+            parse={value => Number(value)}
+          />
+        </div>
+      </div>
+      <div className={s.inputGroup}>
+        <button className={`${s.btn} ${s.primary}`} type="submit" disabled={disableSubmit}>
+          Save
+        </button>
+      </div>
+      <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
         <Field
-          label="Organization"
+          label="Add Volunteer (by email)"
           className={s.field}
-          name="organization.id"
+          name="volunteerEmail"
           component={renderField}
-          organizations={organizations}
-          Custom={OrganizationField}
+          optional="true"
+          type="text"
         />
       </div>
-    </div>
-    <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
-      <div className={s.column}>
-        <Field label="Office" className={s.field} name="office.id" component={renderField} type="select">
-          <option value="-" key="-" />
-          {R.map(
-            office => (
-              <option value={office.id} key={`office-${office.id}`}>
-                {office.name}
-              </option>
-            ),
-            offices
-          )}
-        </Field>
+      <div className={s.inputGroup}>
+        <button
+          className={`${s.btn} ${s.primary}`}
+          type="button"
+          name="addVolunteerButton"
+          onClick={e => createSignup({ email: e.target.form.elements.volunteerEmail.value })}
+        >
+          Add
+        </button>
       </div>
-      <div className={s.column}>
-        <Field label="Location" className={s.field} name="location" component={renderField} Custom={LocationField} />
-      </div>
-    </div>
-    <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
-      <div className={s.column}>
-        <Field label="Start Date" className={s.field} name="startsAt" component={renderField} Custom={DateField} />
-      </div>
-      <div className={s.column}>
-        <Field label="Start Time" className={s.field} name="startsAt" component={renderField} Custom={TimeField} />
-      </div>
-    </div>
-    <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
-      <div className={s.column}>
-        <Field label="End Date" className={s.field} name="endsAt" component={renderField} Custom={DateField} />
-      </div>
-      <div className={s.column}>
-        <Field label="End Time" className={s.field} name="endsAt" component={renderField} Custom={TimeField} />
-      </div>
-    </div>
-    <div className={`${s.inputGroup} ${s.twoColumnForm}`}>
-      <div className={s.column}>
-        <Field
-          label="Capacity"
-          className={s.field}
-          name="capacity"
-          component={renderField}
-          type="number"
-          parse={value => Number(value)}
-        />
-      </div>
-    </div>
-    <div className={s.inputGroup}>
-      <button className={`${s.btn} ${s.primary}`} type="submit" disabled={disableSubmit}>
-        Save
-      </button>
-    </div>
-    <UserList users={users} destroySignup={destroySignup} />
-  </form>
-)
+      <UserList users={users} destroySignup={destroySignup} />
+    </form>
+  )
+}
 
 export default EventForm

--- a/app/javascript/mutations/CreateSignupMutation.gql
+++ b/app/javascript/mutations/CreateSignupMutation.gql
@@ -1,8 +1,8 @@
 #import "fragments/EventEntry.gql"
 #import "fragments/UserEntry.gql"
 
-mutation createSignup($eventId: ID!) {
-  createSignup(eventId: $eventId) {
+mutation createSignup($eventId: ID!, $userEmail: String) {
+  createSignup(eventId: $eventId, userEmail: $userEmail) {
     event {
       ...EventEntry
       users {

--- a/app/javascript/pages/admin/Events/form.js
+++ b/app/javascript/pages/admin/Events/form.js
@@ -52,6 +52,7 @@ const EventFormPage = ({
   submitting,
   graphQLErrors,
   users,
+  createSignup,
   destroySignup,
 }) => (
   <EventForm
@@ -60,6 +61,7 @@ const EventFormPage = ({
     organizations={organizations}
     handleSubmit={handleSubmit}
     users={users}
+    createSignup={createSignup}
     destroySignup={destroySignup}
     disableSubmit={pristine || submitting}
     errors={graphQLErrors}


### PR DESCRIPTION

## Description
Add a new feature that allows admin to add individual volunteer by the email on Event edit page.


## Implementation notes (if needed)
Need to disable `Add` button when the email address is blank/invalid.

## Tasks (if needed)
- [ ] Write tests

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img width="993" alt="Screen Shot 2020-02-26 at 3 38 45 pm" src="https://user-images.githubusercontent.com/489032/75312475-2108cc80-58ae-11ea-9b23-4762b6a7c266.png">

</details>

<details>
<summary>After</summary>
<img width="998" alt="Screen Shot 2020-02-26 at 3 36 54 pm" src="https://user-images.githubusercontent.com/489032/75312494-2bc36180-58ae-11ea-8500-1036fa08f947.png">

</details>

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [HIGH | medium | low] - low
