### PR TITLE
Add function to allow admin to edit a tag

### DIFF
--- a/app/graphql/mutations/update_tag.rb
+++ b/app/graphql/mutations/update_tag.rb
@@ -1,0 +1,13 @@
+module Mutations
+  class UpdateTag < BaseMutation
+    require_admin
+
+    null true
+
+    argument :input, Types::Input::EditTagInputType, required: true
+
+    def resolve(**args)
+      TagResolver.update(object, args, context)
+    end
+  end
+end

--- a/app/graphql/resolvers/tag_resolver.rb
+++ b/app/graphql/resolvers/tag_resolver.rb
@@ -8,9 +8,13 @@ module TagResolver
       tag
     end
 
-    # def update(_, args, _context)
-    # TODO
-    # end
+    def update(_, args, _context)
+      tag = Tag.find(args[:input].id)
+      tag.name = args[:input].name
+      tag.save!
+
+      tag
+    end
 
     def delete(_, args, _context)
       tag = Tag.find(args[:id])

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -32,8 +32,8 @@ module Types
     field :delete_event_type, EventTypeGraphType, mutation: Mutations::DeleteEventType
 
     field :create_tag, TagGraphType, mutation: Mutations::CreateTag
+    field :update_tag, TagGraphType, mutation: Mutations::UpdateTag
     field :delete_tag, TagGraphType, mutation: Mutations::DeleteTag
-    # TODO: update_tag
 
     field :confirm_profile_settings, UserPreferenceGraphType, mutation: Mutations::ConfirmProfileSettings
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -105,6 +105,13 @@ module Types
       IndividualEvent.pending.all
     end
 
+    field :tag, TagGraphType, null: true do
+      argument :id, ID, required: true
+    end
+    def tag(id:)
+      RecordLoader.for(Tag).load(id)
+    end
+
     field :tags, [TagGraphType], null: true
     def tags
       Tag.all

--- a/app/graphql/types/tag_graph_type.rb
+++ b/app/graphql/types/tag_graph_type.rb
@@ -1,7 +1,7 @@
 module Types
   class TagGraphType < BaseObject
-    graphql_name 'Tags'
-    description 'Tags for events'
+    graphql_name 'Tag'
+    description 'Tag for events'
 
     implements GraphQL::Relay::Node.interface
 

--- a/app/javascript/fragments/TagEntry.gql
+++ b/app/javascript/fragments/TagEntry.gql
@@ -1,0 +1,4 @@
+fragment TagEntry on Tag {
+  id
+  name
+}

--- a/app/javascript/mutations/CreateEditIndividualEventMutation.gql
+++ b/app/javascript/mutations/CreateEditIndividualEventMutation.gql
@@ -1,6 +1,7 @@
 #import "fragments/OrganizationEntry.gql"
 #import "fragments/OfficeEntry.gql"
 #import "fragments/EventTypeEntry.gql"
+#import "fragments/TagEntry.gql"
 
 mutation createEditIndividualEvent($input: CreateEditIndividualEventInputType!) {
   createEditIndividualEvent(input: $input) {
@@ -18,8 +19,7 @@ mutation createEditIndividualEvent($input: CreateEditIndividualEventInputType!) 
         ...EventTypeEntry
       }
       tags {
-        id
-        name
+        ...TagEntry
       }
       office {
         ...OfficeEntry

--- a/app/javascript/pages/admin/Tags/edit.js
+++ b/app/javascript/pages/admin/Tags/edit.js
@@ -1,28 +1,40 @@
-import React from 'react'
-import { graphql, compose } from 'react-apollo'
-import { useQuery } from '@apollo/react-hooks'
-import { NetworkStatus } from 'apollo-client'
-import { connect } from 'react-redux'
 import * as R from 'ramda'
+import React, { useState } from 'react'
 
-import { graphQLError } from 'actions'
+import { useMutation, useQuery } from '@apollo/react-hooks'
 
-import TagForm from './form'
 import Loading from 'components/LoadingIcon'
-
+import TagForm from './form'
 import TagQuery from './queries/show.gql'
 import UpdateTagMutation from './mutations/update.gql'
 
 const EditTag = props => {
-  const { updateTag } = props
+  const [updateError, setUpdateError] = useState(null)
   const { data, loading, error } = useQuery(TagQuery, {
     variables: { id: props.params.id },
   })
+  const [mutate, _] = useMutation(UpdateTagMutation)
+  const updateTag = tag => {
+    mutate({
+      variables: { input: R.omit(['__typename'], tag) },
+      optimisticResponse: buildOptimisticResponse(tag),
+    })
+      .then(_response => {
+        props.router.push('/portal/admin/tags')
+      })
+      .catch(({ graphQLErrors }) => {
+        setUpdateError(graphQLErrors)
+      })
+  }
 
   if (loading) return <Loading />
   if (error) return <div>Tag Not Found</div>
-
-  return <TagForm tag={data.tag} onSubmit={updateTag} />
+  return (
+    <>
+      {updateError && <p>Unable to update the tags</p>}
+      <TagForm tag={data.tag} onSubmit={updateTag} />
+    </>
+  )
 }
 
 const buildOptimisticResponse = tag => ({
@@ -33,31 +45,4 @@ const buildOptimisticResponse = tag => ({
   },
 })
 
-const withData = compose(
-  graphql(UpdateTagMutation, {
-    props: ({ ownProps, mutate }) => ({
-      updateTag: tag =>
-        mutate({
-          variables: { input: R.omit(['__typename'], tag) },
-          optimisticResponse: buildOptimisticResponse(tag),
-        })
-          .then(_response => {
-            ownProps.router.push('/portal/admin/tags')
-          })
-          .catch(({ graphQLErrors }) => {
-            ownProps.graphQLError('tag', graphQLErrors)
-          }),
-    }),
-  })
-)
-
-const mapStateToProps = (state, ownProps) => ({})
-
-const withActions = connect(
-  mapStateToProps,
-  {
-    graphQLError,
-  }
-)
-
-export default withActions(withData(EditTag))
+export default EditTag

--- a/app/javascript/pages/admin/Tags/edit.js
+++ b/app/javascript/pages/admin/Tags/edit.js
@@ -1,12 +1,20 @@
 import * as R from 'ramda'
 import React, { useState } from 'react'
 
+import styled from 'styled-components'
+import { Alert, Title } from '@zendeskgarden/react-notifications'
 import { useMutation, useQuery } from '@apollo/react-hooks'
 
 import Loading from 'components/LoadingIcon'
 import TagForm from './form'
 import TagQuery from './queries/show.gql'
 import UpdateTagMutation from './mutations/update.gql'
+
+const spacingSm = R.pathOr('50px', ['theme', 'styles', 'spacing', 'sm'])
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${spacingSm};
+`
 
 const EditTag = props => {
   const [updateError, setUpdateError] = useState(null)
@@ -28,10 +36,20 @@ const EditTag = props => {
   }
 
   if (loading) return <Loading />
-  if (error) return <div>Tag Not Found</div>
+  if (error)
+    return (
+      <StyledAlert type="error">
+        <Title>Tag Not Found</Title>
+      </StyledAlert>
+    )
   return (
     <>
-      {updateError && <p>Unable to update the tags</p>}
+      {updateError && (
+        <StyledAlert type="error">
+          <Title>Update Failed</Title>
+          An error occured in the server, unable to update the tag.
+        </StyledAlert>
+      )}
       <TagForm tag={data.tag} onSubmit={updateTag} />
     </>
   )

--- a/app/javascript/pages/admin/Tags/edit.js
+++ b/app/javascript/pages/admin/Tags/edit.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { graphql, compose } from 'react-apollo'
+import { NetworkStatus } from 'apollo-client'
+import { connect } from 'react-redux'
+import * as R from 'ramda'
+
+import { graphQLError } from 'actions'
+
+import TagForm from './form'
+import Loading from 'components/LoadingIcon'
+
+import TagQuery from './queries/show.gql'
+import UpdateTagMutation from './mutations/update.gql'
+
+const EditTag = ({ data: { networkStatus, tag }, updateTag }) =>
+  networkStatus === NetworkStatus.loading ? <Loading /> : <TagForm tag={tag} onSubmit={updateTag} />
+
+const buildOptimisticResponse = tag => ({
+  __typename: 'Mutation',
+  updateTag: {
+    __typename: 'tag',
+    ...tag,
+  },
+})
+
+const withData = compose(
+  graphql(TagQuery, {
+    options: ({ params: { id } }) => ({
+      variables: { id },
+    }),
+  }),
+  graphql(UpdateTagMutation, {
+    props: ({ ownProps, mutate }) => ({
+      updateTag: tag =>
+        mutate({
+          variables: { input: R.omit(['__typename'], tag) },
+          optimisticResponse: buildOptimisticResponse(tag),
+        })
+          .then(_response => {
+            ownProps.router.push('/portal/admin/tags')
+          })
+          .catch(({ graphQLErrors }) => {
+            ownProps.graphQLError('tag', graphQLErrors)
+          }),
+    }),
+  })
+)
+
+const mapStateToProps = (state, ownProps) => ({})
+
+const withActions = connect(
+  mapStateToProps,
+  {
+    graphQLError,
+  }
+)
+
+export default withActions(withData(EditTag))

--- a/app/javascript/pages/admin/Tags/edit.js
+++ b/app/javascript/pages/admin/Tags/edit.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { graphql, compose } from 'react-apollo'
+import { useQuery } from '@apollo/react-hooks'
 import { NetworkStatus } from 'apollo-client'
 import { connect } from 'react-redux'
 import * as R from 'ramda'
@@ -12,8 +13,17 @@ import Loading from 'components/LoadingIcon'
 import TagQuery from './queries/show.gql'
 import UpdateTagMutation from './mutations/update.gql'
 
-const EditTag = ({ data: { networkStatus, tag }, updateTag }) =>
-  networkStatus === NetworkStatus.loading ? <Loading /> : <TagForm tag={tag} onSubmit={updateTag} />
+const EditTag = props => {
+  const { updateTag } = props
+  const { data, loading, error } = useQuery(TagQuery, {
+    variables: { id: props.params.id },
+  })
+
+  if (loading) return <Loading />
+  if (error) return <div>Tag Not Found</div>
+
+  return <TagForm tag={data.tag} onSubmit={updateTag} />
+}
 
 const buildOptimisticResponse = tag => ({
   __typename: 'Mutation',
@@ -24,11 +34,6 @@ const buildOptimisticResponse = tag => ({
 })
 
 const withData = compose(
-  graphql(TagQuery, {
-    options: ({ params: { id } }) => ({
-      variables: { id },
-    }),
-  }),
   graphql(UpdateTagMutation, {
     props: ({ ownProps, mutate }) => ({
       updateTag: tag =>

--- a/app/javascript/pages/admin/Tags/index.js
+++ b/app/javascript/pages/admin/Tags/index.js
@@ -20,6 +20,7 @@ import s from './main.css'
 
 const actionLinks = (tag, togglePopover) => (
   <div className={s.actionColumn}>
+    <Link to={`/portal/admin/tags/${tag.id}/edit`}>Edit</Link>
     <button className={s.deleteAction} onClick={() => togglePopover('destroyTag', tag)}>
       Delete
     </button>

--- a/app/javascript/pages/admin/Tags/mutations/update.gql
+++ b/app/javascript/pages/admin/Tags/mutations/update.gql
@@ -1,0 +1,7 @@
+#import "fragments/TagEntry.gql"
+
+mutation updateTag($input: EditTagInputType!) {
+  updateTag(input: $input) {
+    ...TagEntry
+  }
+}

--- a/app/javascript/pages/admin/Tags/queries/show.gql
+++ b/app/javascript/pages/admin/Tags/queries/show.gql
@@ -1,0 +1,7 @@
+#import "fragments/TagEntry.gql"
+
+query TagQuery($id: ID!) {
+  tag(id: $id) {
+    ...TagEntry
+  }
+}

--- a/app/javascript/routes.js
+++ b/app/javascript/routes.js
@@ -22,6 +22,7 @@ import NewEventType from 'pages/admin/EventTypes/new'
 import EditEventType from 'pages/admin/EventTypes/edit'
 import TagsAdmin from 'pages/admin/Tags'
 import NewTags from 'pages/admin/Tags/new'
+import EditTag from 'pages/admin/Tags/edit'
 import UsersAdmin from 'pages/admin/Users'
 import EditUser from 'pages/admin/Users/edit'
 import IndividualEventsAdmin from 'pages/admin/IndividualEvents'
@@ -47,6 +48,7 @@ export default (
         <Route path="/portal/admin/event-types" component={EventTypesAdmin} />
         <Route path="/portal/admin/tags" component={TagsAdmin} />
         <Route path="/portal/admin/tags/new" component={NewTags} />
+        <Route path="/portal/admin/tags/:id/edit" component={EditTag} />
         <Route path="/portal/admin/individual_events" component={IndividualEventsAdmin} />
         <Route path="/portal/admin/users/:id/edit" component={EditUser} />
         <Route path="/portal/admin/users" component={UsersAdmin} />

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,11 @@ ActiveRecord::Schema.define(version: 20200114001524) do
     t.index ["updated_at"], name: "index_events_on_updated_at"
   end
 
+  create_table "events_tags", id: false, force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "tag_id", null: false
+  end
+
   create_table "individual_event_tags", force: :cascade do |t|
     t.bigint "individual_event_id"
     t.bigint "tag_id"

--- a/test/graphql/resolvers/tag_resolver_test.rb
+++ b/test/graphql/resolvers/tag_resolver_test.rb
@@ -17,6 +17,20 @@ describe TagResolver do
     end
   end
 
+  describe '.update' do
+    let(:tag) { tags(:minimum) }
+
+    it 'updates the given tag' do
+      input = stub(id: tag.id, name: 'Sustainability')
+
+      TagResolver.update(nil, { input: input }, nil)
+
+      t = Tag.find(tag.id)
+
+      assert_equal 'Sustainability', t.name
+    end
+  end
+
   describe '.delete' do
     let(:tag) { tags(:minimum) }
 

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -46,6 +46,7 @@ describe 'cleanliness' do
         app/graphql/mutations/update_user_office.rb
         app/graphql/mutations/delete_tag.rb
         app/graphql/mutations/create_tag.rb
+        app/graphql/mutations/update_tag.rb
         app/graphql/mutations/confirm_profile_settings.rb
         app/graphql/portal_schema.rb
         app/graphql/resolvers/office_resolver.rb


### PR DESCRIPTION
## Description
Allow admins to be able to edit the tag name.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/295)


## Screenshots (if needed)
<details>
<summary>Before</summary>
<img width="926" alt="Screen Shot 2020-01-15 at 1 05 09 pm" src="https://user-images.githubusercontent.com/42596493/72398637-b2592f00-3797-11ea-9874-6853392cd389.png">
</details>

<details>
<summary>After</summary>
<img width="919" alt="Screen Shot 2020-01-15 at 1 01 29 pm" src="https://user-images.githubusercontent.com/42596493/72398604-96558d80-3797-11ea-9752-e410acc19844.png">
</details>
