### PR TITLE
Use icons instead of text for arrows to navigate calendar

### DIFF
--- a/app/javascript/components/Toolbar/index.js
+++ b/app/javascript/components/Toolbar/index.js
@@ -9,6 +9,9 @@ import EventFilter from 'components/EventFilter'
 import OfficeFilter from 'components/OfficeFilter'
 import FilterGroup from 'components/FilterGroup'
 
+import LeftIcon from '@zendeskgarden/svg-icons/src/12/chevron-left-fill.svg'
+import RightIcon from '@zendeskgarden/svg-icons/src/12/chevron-right-fill.svg'
+
 import s from './main.css'
 
 const translations = R.flip(R.mapObjIndexed)({
@@ -18,8 +21,6 @@ const translations = R.flip(R.mapObjIndexed)({
   day: 'volunteer_portal.calendar.bigcalendar.day',
   agenda: 'volunteer_portal.calendar.bigcalendar.agenda',
   today: 'volunteer_portal.dashboard.layoutdatetab.today',
-  previous: 'volunteer_portal.dashboard.layoutdatetab.previous',
-  after: 'volunteer_portal.dashboard.layoutdatetab.after',
 })
 
 const Toolbar = ({ label, view, views, onNavigate, onViewChange, t }) => {
@@ -32,11 +33,11 @@ const Toolbar = ({ label, view, views, onNavigate, onViewChange, t }) => {
           {text.today}
         </button>
         <button className={s.btn} type="button" onClick={() => onNavigate(navigate.PREVIOUS)}>
-          {text.previous}
+          <LeftIcon />
         </button>
         <span className={s.label}>{label}</span>
         <button className={s.btn} type="button" onClick={() => onNavigate(navigate.NEXT)}>
-          {text.after}
+          <RightIcon />
         </button>
       </div>
       <div className={s.filterBar}>

--- a/config/locales/en.csv
+++ b/config/locales/en.csv
@@ -4,8 +4,6 @@ volunteer_portal.dashboard.layouttab.calendar,Calendar,Clickable tab that displa
 volunteer_portal.dashboard.layouttab.dashboard,Dashboard,Clickable tab that displays the Dashboard View,https://drive.google.com/open?id=17xYrax65oH20lvlK6Cdd9flO1MVUp2-4,TRUE
 volunteer_portal.dashboard.layouttab.myevents,My Events,Clickable tab that displays the user related events,https://drive.google.com/open?id=1sbs3Uo2e764YFh40Na2DQsdahVD2W-Ne,TRUE
 volunteer_portal.dashboard.layoutdatetab.today,Today,Clickable text that will show the calendar with today's date,https://drive.google.com/open?id=1pO28Ugnx0UGXP5E3dM8y0LpogdPc5Cnt,TRUE
-volunteer_portal.dashboard.layoutdatetab.previous,<,Navigation button that shows the previous month in the calendar,https://drive.google.com/open?id=1kdbd52lLRtsoDaaiG12mVaSedPZG6lM2,TRUE
-volunteer_portal.dashboard.layoutdatetab.after,>,Navigation button that shows the next month in the calendar,https://drive.google.com/open?id=19Qo63AHICWMbdFpve_SnlZjHmA-ZogMK,TRUE
 volunteer_portal.dashboard.layouteventstab.show,Show:,Text refering to what events to show My Events or All Events,https://drive.google.com/open?id=1p9A8huzT8xpJmwKY6P_Ci4sqC6uh7r_t,TRUE
 volunteer_portal.dashboard.layouteventstab.show_all,All,Dropdown to choose between seeing All Events or My Events only,https://drive.google.com/open?id=1lsq8KegHPQ34zhTJKvUsQTXro9dV3Ic6,TRUE
 volunteer_portal.dashboard.layouteventstab.show_myevents,My Events,Dropdown to choose between seeing All Events or My Events only,https://drive.google.com/open?id=1gshUUNWv0KL4idMo_e4DdYweouTdLwRl,TRUE

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -6,8 +6,6 @@
       "volunteer_portal.dashboard.layouttab.dashboard": "Dashboard",
       "volunteer_portal.dashboard.layouttab.myevents": "My Events",
       "volunteer_portal.dashboard.layoutdatetab.today": "Today",
-      "volunteer_portal.dashboard.layoutdatetab.previous": "<",
-      "volunteer_portal.dashboard.layoutdatetab.after": ">",
       "volunteer_portal.dashboard.layouteventstab.show": "Show:",
       "volunteer_portal.dashboard.layouteventstab.show_all": "All",
       "volunteer_portal.dashboard.layouteventstab.show_myevents": "My Events",


### PR DESCRIPTION
To make look more functional and looks better.

## Before
![image](https://user-images.githubusercontent.com/27116427/77497335-2f440b80-6ea1-11ea-9a8b-6cfba68ad8da.png)


## After
![image](https://user-images.githubusercontent.com/27116427/77497344-3408bf80-6ea1-11ea-9efa-419cc25b8b21.png)
