### PR TITLE
Populate tags for volunteer portals without tags.

### DIFF
--- a/db/migrate/20200506054322_no_empty_tags.rb
+++ b/db/migrate/20200506054322_no_empty_tags.rb
@@ -1,9 +1,9 @@
 class NoEmptyTags < ActiveRecord::Migration[5.1]
   def change
-    if Tag.all.length == 0
-      [
-        'New Hire', 'Skilled', 'Sustainability'
-      ].each { |tag| Tag.find_or_create_by(name: tag) }
-    end
+    return unless Tag.all.length.zero?
+
+    [
+      'New Hire', 'Skilled', 'Sustainability'
+    ].each { |tag| Tag.find_or_create_by(name: tag) }
   end
 end

--- a/db/migrate/20200506054322_no_empty_tags.rb
+++ b/db/migrate/20200506054322_no_empty_tags.rb
@@ -1,0 +1,9 @@
+class NoEmptyTags < ActiveRecord::Migration[5.1]
+  def change
+    if Tag.all.length == 0
+      [
+        'New Hire', 'Skilled', 'Sustainability'
+      ].each { |tag| Tag.find_or_create_by(name: tag) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200114001524) do
+ActiveRecord::Schema.define(version: 20200506054322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,11 +58,6 @@ ActiveRecord::Schema.define(version: 20200114001524) do
     t.index ["event_type_id"], name: "index_events_on_event_type_id"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["updated_at"], name: "index_events_on_updated_at"
-  end
-
-  create_table "events_tags", id: false, force: :cascade do |t|
-    t.bigint "event_id", null: false
-    t.bigint "tag_id", null: false
   end
 
   create_table "individual_event_tags", force: :cascade do |t|


### PR DESCRIPTION
## Description
This is because all events require at least one tag, for now. In the future when there's an option to make it optional, we can remove this migration.

This is especially important for old volunteer portals that have migrated on to with tags. Not so important for new portals since they have the seed file.

## Tasks (if needed)
- [x] Tested locally

## CCs
If app migration related
@zendesk/volunteer

## Risks (if any)
* [HIGH | medium | low] - low
