### PR TITLE
Don't use locale date strings when creating event.

### DIFF
--- a/app/javascript/pages/MyEvents/CreateEditModalContents.jsx
+++ b/app/javascript/pages/MyEvents/CreateEditModalContents.jsx
@@ -65,7 +65,7 @@ const CreateEditModalContents = ({
         description,
         tags: selectedTags,
         officeId: selectedOffice,
-        date: date.toLocaleString(),
+        date: date.toISOString(),
         duration,
         eventTypeId: selectedEventType,
         organizationId: selectedOrg,


### PR DESCRIPTION
Minor oops that I made. It messes up communication with server if user has a non-supported locale string (in one case, having AM and PM).

solves #352 