### PR TITLE
Format date in CreateEditModalContents to fix timezone issues

### DIFF
--- a/app/javascript/pages/MyEvents/CreateEditModalContents.jsx
+++ b/app/javascript/pages/MyEvents/CreateEditModalContents.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react'
 
+import moment from 'moment'
 import ReduxFormAutocomplete from 'components/ReduxFormAutoComplete'
 import TagField from 'components/TagField'
 import { UserContext } from '../../context/UserContext'
@@ -65,7 +66,7 @@ const CreateEditModalContents = ({
         description,
         tags: selectedTags,
         officeId: selectedOffice,
-        date: date.toISOString(),
+        date: moment(date).format('YYYY-MM-DD'),
         duration,
         eventTypeId: selectedEventType,
         organizationId: selectedOrg,


### PR DESCRIPTION
## Description
When recording an Individual event, we store the date. This has previously been stored as date and time and caused timezone issues. As we only collect the date the user inputs, we will only store the date. 
Use moment (existing library in project) to format the date into international format. 

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/352)

## Screenshots

<img width="776" alt="image" src="https://user-images.githubusercontent.com/10415617/83591407-32433280-a59b-11ea-9a34-c437a9bcd269.png">

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* Low: Date is not currently working properly anyway, this only modifies the date
