### PR TITLE
Update vendor/cache after dependabot creates gem PR

### DIFF
--- a/.github/workflows/update-gems-after-dependabot.yml
+++ b/.github/workflows/update-gems-after-dependabot.yml
@@ -1,0 +1,40 @@
+---
+name: Update Gems after Dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/bundler/**'
+    paths:
+      - 'Gemfile.lock'
+
+jobs:
+  update-gems:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby and Bundler
+        uses: actions/setup-ruby@v1
+
+      - name: Cache gems
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: bundler-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            bundler-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-
+
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Push a commit with changes to vendor/cache
+        run: |
+          git config --local user.email `git show -s --format='%ae'`
+          git config --local user.name ${GITHUB_ACTOR}
+          git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+          git add vendor/cache
+          git commit -m "`git log --oneline --format=%B -n 1 HEAD | head -n 1` - add gems"
+          git push github HEAD:${GITHUB_REF}


### PR DESCRIPTION
Update vendor/cache directory after dependabot creates a PR for gems

## Description
- Dependabot does not yet update `vendor/cache` for us. This GitHub Action will run when a dependabot PR is created for a Ruby gem and add `vendor/cache`.
- Dependabot generates PRs for us when packages need upgrading or there are security vulnerabilities. However there is no ability (at least not yet) to auto update our vendor/cache files. This means we must check out each branch created by dependabot and run bundle and commit manually to get the vendor/cache files.

Please note that this action will stop further rebases of the branch to either rebase of master or to rebase when a newer version is available.

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* Low: build should break if this doesn't work
