### PR TITLE
Fix up puma version in Gemfile.lock to match vendor/cache

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     pg (0.21.0)
     promise.rb (0.7.4)
     public_suffix (4.0.5)
-    puma (3.12.4)
+    puma (3.12.6)
     rack (2.2.3)
     rack-attack (6.2.1)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
## Description

Match vendor/cache file with Gemfile.lock file for puma (this was originally bumped by dependabot to patch a security vulnerability - but somehow it went missing)

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* Low: fix version
