### PR TITLE
Save request path before redirecting to login screen. resume url after authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,7 @@ class ApplicationController < ActionController::Base
     return if current_user
 
     reset_session # make sure the session isn't poluted with a user_id we couldn't find
+    session[:return_to] ||= request.env['REQUEST_PATH']
     redirect_to :login
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
     return if current_user
 
     reset_session # make sure the session isn't poluted with a user_id we couldn't find
-    session[:return_to] ||= request.env['REQUEST_PATH']
+    session[:return_to] ||= request.fullpath
     redirect_to :login
   end
 

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -28,7 +28,7 @@ class OmniauthCallbacksController < ActionController::Base
       redirect_to params[:return_to]
     else
       return_to = session.delete(:return_to)
-      if return_to then redirect_to return_to else redirect_to :portal end
+      return_to ? (redirect_to return_to) : (redirect_to :portal)
     end
   rescue ActiveRecord::RecordInvalid => e
     render text: e.message, status: :forbidden

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -27,7 +27,8 @@ class OmniauthCallbacksController < ActionController::Base
     if params[:return_to]&.include?(root_url)
       redirect_to params[:return_to]
     else
-      redirect_to :portal
+      return_to = session.delete(:return_to)
+      if return_to then redirect_to return_to else redirect_to :portal end
     end
   rescue ActiveRecord::RecordInvalid => e
     render text: e.message, status: :forbidden


### PR DESCRIPTION
Solves #226 

## Description
Say a user wants to visit an event `http://localhost:5000/portal/events/81`, if they're not already authenticated, it'll send them to the login screen. Then after login they' will be redirected. Before this PR, they'll always be sent to the home screen. After this PR, they will be sent back to the original url.

## Risks
* low
