### PR TITLE
add page with link to privacy policy

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,6 +53,10 @@
       "description": "Google tag manager ID. Create an account to add analytics etc.",
       "required": false
     },
+    "PRIVACY_POLICY_LINK": {
+      "description": "The portal privacy policy page will have a link to this link. Required for google oauth.",
+      "required": false
+    },
     "IP_BLOCK_ALL": {
       "description": "If enabled (IP_BLOCK_ALL='true') then all IP addresses will be blocked. Add IPs to the safe list to allow access.",
       "required": false

--- a/app/controllers/legal_controller.rb
+++ b/app/controllers/legal_controller.rb
@@ -1,0 +1,9 @@
+# rubocop:disable Rails/ApplicationController
+class LegalController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  def index
+    render "privacy.html.erb"
+  end
+end
+# rubocop:enable Rails/ApplicationController

--- a/app/views/legal/privacy.html.erb
+++ b/app/views/legal/privacy.html.erb
@@ -1,0 +1,9 @@
+<div id="root">
+  <div style="margin:0 auto;text-align:center;">
+    <h3>Privacy Policy</h3>
+    <% if ENV['PRIVACY_POLICY_LINK'] %>
+      <p>Please read our <a href="<%= ENV['PRIVACY_POLICY_LINK'] %>" target="_blank">privacy policy</a>.</p>
+    <% else %>
+      <p>Sorry, no policy has been crafted yet.</p>
+    <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   root 'standalone#portal'
 
+  get 'legal',        to: 'legal#index'
+
   get 'volunteer/ping', to: 'ping#index'
   get 'z/ping',         to: 'ping#index'
 

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -20,6 +20,7 @@ describe 'cleanliness' do
         app/controllers/application_controller.rb
         app/controllers/gauth_controller.rb
         app/controllers/graphql_controller.rb
+        app/controllers/legal_controller.rb
         app/controllers/omniauth_callbacks_controller.rb
         app/controllers/ping_controller.rb
         app/controllers/standalone_controller.rb


### PR DESCRIPTION
## Description
For google auth, administrators need to provide a privacy policy to be verified by google.

We expose an environment variable that is a link to where this page will go.

I'll admit, looks rough, but does the job. The alternative is an iframe (but harder due to security x-domain).

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/385)

## Screenshots (if needed)
![image](https://user-images.githubusercontent.com/27116427/88764707-c951f280-d1b8-11ea-95c4-e31d128be5c5.png)


## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [HIGH | medium | low] - low
