### PR TITLE
wrap hours in a span to center align

### DIFF
--- a/app/javascript/pages/Dashboard/Leaderboard/index.js
+++ b/app/javascript/pages/Dashboard/Leaderboard/index.js
@@ -30,7 +30,7 @@ const SectionTitle = styled(LG)`
   align-self: flex-end;
 `
 
-const Loader = _props => (
+const Loader = (_props) => (
   <>
     {Array(10)
       .fill()
@@ -51,7 +51,7 @@ const nowInSec = moment().unix()
 const leaderBoardSize = 10
 const leaderBoardSort = 'HOURS_DESC'
 
-const Leaderboard = _props => {
+const Leaderboard = (_props) => {
   const { filters } = useContext(FilterContext)
   const { loading, error, data } = useQuery(LeaderboardQuery, {
     variables: {
@@ -90,7 +90,7 @@ const Leaderboard = _props => {
             <NamedAvatar image={user.photo} name={user.name} />
             <MD>
               <Tag isPill size="large">
-                {user.hours}
+                <span>{user.hours}</span>
               </Tag>{' '}
               {t('volunteer_portal.admin.tab.user.dashboard.topvolunteers.hours')}
             </MD>


### PR DESCRIPTION
## Description
Allows centre align from top component to trickle down to the text. It's also the recommended usage: https://garden.zendesk.com/components/tags#shape


## Screenshots (if needed)
### Before
![image](https://user-images.githubusercontent.com/27116427/98066190-5e484400-1eaa-11eb-9e4f-b76c9af24f87.png)


### After
![image](https://user-images.githubusercontent.com/27116427/98066195-630cf800-1eaa-11eb-9fcf-d690ead7dfed.png)

## Risks (if any)
* Low
