### PR TITLE
Change EventPopover to use garden components

### DIFF
--- a/app/javascript/components/Blackout/index.js
+++ b/app/javascript/components/Blackout/index.js
@@ -1,8 +1,0 @@
-import React from 'react'
-import * as R from 'ramda'
-
-import s from './main.css'
-
-const Blackout = ({ width }) => <span className={s.blackout}>{'W'.repeat(width)}</span>
-
-export default Blackout

--- a/app/javascript/components/Blackout/main.css
+++ b/app/javascript/components/Blackout/main.css
@@ -1,6 +1,0 @@
-.blackout {
-  color: #ddd;
-  background-color: #ddd;
-  padding: 1px 2px;
-  border-radius: 5px;
-}

--- a/app/javascript/components/EventPopover/index.js
+++ b/app/javascript/components/EventPopover/index.js
@@ -1,32 +1,23 @@
 import React from 'react'
 import { Link } from 'react-router'
-import * as R from 'ramda'
-import Popover from 'material-ui/Popover'
+import { TooltipModal } from '@zendeskgarden/react-modals'
 
 import EventLocation from 'components/EventLocation'
 import EventTime from 'components/EventTime'
 import AvatarGroup from 'components/AvatarGroup'
 import SignupButton from 'components/SignupButton'
-import Blackout from 'components/Blackout'
+import { Skeleton } from '@zendeskgarden/react-loaders'
 
 import s from './main.css'
 
 import { useTranslation } from 'react-i18next'
 
-// Material UI components still require inline styles
-const styles = {
-  popover: {
-    marginTop: 5,
-    fontWeight: 400,
-  },
-}
-
-const renderEventDescription = event =>
+const renderEventDescription = (event) =>
   event.description.length > 255 ? `${event.description.slice(0, 256)}...` : event.description
 
-const photoUrls = users => users.map(u => u.photo)
+const photoUrls = (users) => users.map((u) => u.photo)
 
-const renderAdditionalCountAvatar = users =>
+const renderAdditionalCountAvatar = (users) =>
   users.length > 3 ? (
     <figure className={s.figure}>
       <svg className={s.svg}>
@@ -49,18 +40,18 @@ const EventProperties = ({ event }) =>
     </div>
   ) : (
     <div>
-      <p className={s.description}>
+      <div className={s.description}>
         <span className={s.eventTitle}>
-          <Blackout width={8} />
+          <Skeleton width="80%" />
         </span>
         <span className={s.eventType}>
-          <Blackout width={5} />
+          <Skeleton width="50%" />
         </span>
-        <Blackout width={10} />
-      </p>
-      <Blackout width={8} />
-      <p />
-      <Blackout width={8} />
+        <Skeleton width="100%" />
+      </div>
+      <Skeleton width="80%" />
+      <div />
+      <Skeleton width="80%" />
     </div>
   )
 
@@ -75,7 +66,7 @@ const AttendeeIcons = ({ event }) =>
     <div className={s.attendeeIcons}>
       <AvatarGroup maxAvatars={3} images={[null, null]} />
       <span className={s.spotsAvailable}>
-        <Blackout width={3} />
+        <Skeleton width="30%" />
       </span>
     </div>
   )
@@ -104,29 +95,11 @@ const Actions = ({ event, currentUser, createSignupHandler, destroySignupHandler
     </div>
   )
 
-const EventPopover = ({
-  open,
-  anchorEl,
-  currentUser,
-  event,
-  onPopoverClose,
-  createSignupHandler,
-  destroySignupHandler,
-}) => {
+const EventPopover = ({ anchorEl, currentUser, event, onPopoverClose, createSignupHandler, destroySignupHandler }) => {
   const { t } = useTranslation()
   return (
-    <Popover
-      style={styles.popover}
-      open={open}
-      anchorEl={anchorEl}
-      anchorOrigin={{ horizontal: 'middle', vertical: 'bottom' }}
-      targetOrigin={{ horizontal: 'middle', vertical: 'top' }}
-      onRequestClose={() => onPopoverClose('event')}
-    >
-      <div className={s.popover}>
-        <button className={s.closePopover} onClick={() => onPopoverClose('event')}>
-          ×
-        </button>
+    <TooltipModal referenceElement={anchorEl} onClose={() => onPopoverClose('event')} placement="top">
+      <TooltipModal.Body>
         <EventProperties event={event} />
         <div className={s.attendeeInfo}>
           <div style={{ overflow: 'hidden' }}>
@@ -146,8 +119,9 @@ const EventPopover = ({
           destroySignupHandler={destroySignupHandler}
           t={t}
         />
-      </div>
-    </Popover>
+      </TooltipModal.Body>
+      <TooltipModal.Close aria-label="Close" />
+    </TooltipModal>
   )
 }
 

--- a/app/javascript/pages/Calendar/index.js
+++ b/app/javascript/pages/Calendar/index.js
@@ -61,7 +61,6 @@ const EventPopoverForData = (props) => {
   return (
     <EventPopover
       loading={networkStatus === NetworkStatus.loading}
-      open
       anchorEl={popoverState.anchorEl}
       currentUser={currentUser}
       event={event}


### PR DESCRIPTION
## Description
Changing the EventPopover component to replace the Material UI's Popover with the [Tooltip modal](https://garden.zendesk.com/components/tooltip-modal) from Garden. Additionally this change also replaces the use of the custom Blackout component with Garden's [Skeleton](https://garden.zendesk.com/components/skeleton)

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/411)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/53738056/105945104-b7de9a00-60b8-11eb-999c-d27377c5af72.png" />

</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/53738056/105945170-dc3a7680-60b8-11eb-8484-d37d16223e85.png" />

</details>

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [Low] - React component change but the functionality should be exactly the same
