### PR TITLE
Use Zendesk Garden Spinner for LoadingIcon

### DIFF
--- a/app/javascript/components/LoadingIcon.js
+++ b/app/javascript/components/LoadingIcon.js
@@ -1,17 +1,15 @@
 import React from 'react'
 import * as R from 'ramda'
-import CircularProgress from 'material-ui/CircularProgress'
+import { Spinner } from '@zendeskgarden/react-loaders'
 
 const ownStyles = {
   loading: {
-    left: '50%',
-    marginLeft: -60,
-    stroke: '#30aabc',
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
   },
 }
 
-const LoadingIcon = ({ style }) => (
-  <CircularProgress size={120} thickness={5} color="30aabc" style={R.merge(ownStyles.loading, style)} />
-)
+const LoadingIcon = ({ style }) => <Spinner size="120" color={'#30aabc'} style={R.merge(ownStyles.loading, style)} />
 
 export default LoadingIcon

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@zendeskgarden/react-dropdowns": "^8.14.1",
     "@zendeskgarden/react-forms": "^8.24.0",
     "@zendeskgarden/react-grid": "^8.5.0",
-    "@zendeskgarden/react-loaders": "^8.5.0",
+    "@zendeskgarden/react-loaders": "^8.30.0",
     "@zendeskgarden/react-modals": "^8.5.0",
     "@zendeskgarden/react-notifications": "^8.25.1",
     "@zendeskgarden/react-pagination": "^8.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1253,6 +1260,11 @@
     webpack-assets-manifest "^3.1.1"
     webpack-cli "^3.3.11"
     webpack-sources "^1.4.3"
+
+"@scarf/scarf@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.1.0.tgz#b84b4a91cd938a688d36245b7a7db6fbc476a499"
+  integrity sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -1644,10 +1656,10 @@
     "@babel/runtime" "^7.8.4"
     "@zendeskgarden/container-selection" "^1.3.6"
 
-"@zendeskgarden/container-schedule@^1.3.1":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-schedule/-/container-schedule-1.3.5.tgz#284e58b2f572c0af9e0e06cdaa48ec4f791eb6b2"
-  integrity sha512-2/nOtHpuChXovVqJLhjmyiifUNNEY9AVnW23xAUZ3cXTpiOQuLcaXDr8tFmrK8CrmWL05mJCK3eY95CXoSMdRA==
+"@zendeskgarden/container-schedule@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-schedule/-/container-schedule-1.3.7.tgz#9f51654f04b03b0a78f009ea6cccb88b414add6c"
+  integrity sha512-hw5tGXyk+ivktpFAUxO0YfYjlG9PIRrdSZcQE8vBzgI5fwSNNLODnGOPfAExF+VCiyXQCTYZkMh5vz8zq/dHBg==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
@@ -1731,13 +1743,13 @@
   dependencies:
     polished "^3.5.1"
 
-"@zendeskgarden/react-loaders@^8.5.0":
-  version "8.21.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-loaders/-/react-loaders-8.21.2.tgz#faad5ff4ba6928175fd5d1da182bab156c9b680c"
-  integrity sha512-pmec6NPrHvzzL4E5elCwiJ3k8W44LVOKalL655yWW7tUDH8bas2q7PhGfADo0IJ3sHmjYoN24DNF8L4AJU5cBQ==
+"@zendeskgarden/react-loaders@^8.30.0":
+  version "8.30.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-loaders/-/react-loaders-8.30.0.tgz#4cc0742ca8be3dd79b9fc747e340a8267a2d2fc1"
+  integrity sha512-9ggknH9aIGXvV3cabyti4ty89sNXI8W8gz2QLI/x7oMhkDprakycxY895aLUk6/uidTELQFUGkHNHAVoWZc0KQ==
   dependencies:
-    "@zendeskgarden/container-schedule" "^1.3.1"
-    polished "^3.5.1"
+    "@zendeskgarden/container-schedule" "^1.3.7"
+    polished "^4.0.0"
 
 "@zendeskgarden/react-modals@^8.5.0":
   version "8.21.2"
@@ -8096,6 +8108,14 @@ polished@^3.5.1:
   integrity sha512-yiB2ims2DZPem0kCD6V0wnhcVGFEhNh0Iw0axNpKU+oSAgFt6yx6HxIT23Qg0WWvgS379cS35zT4AOyZZRzpQQ==
   dependencies:
     "@babel/runtime" "^7.9.2"
+
+polished@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.0.tgz#ab80c10e04fdf8795faee723b59577de18d2936b"
+  integrity sha512-y8IInTGHuwku7+O+wsJ7OOvNpJF7EPP/IDzF1uj9UJfEEKpMAfeq5gZ5UrtOksM7Jk4+hBAk6Ce8rFOOF4msZg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@scarf/scarf" "^1.1.0"
 
 popper.js@^1.14.4:
   version "1.16.1"


### PR DESCRIPTION
## Description
Replace MaterialUI with Zendesk Garden Spinner component for LoadingIcon. As part of a larger piece of work to use Zendesk Garden. 

The colour and size of the spinner remains the same.

`LoadingIcon` has been kept as a component as the Spinner needs some styling to stay centered. The CSS in `ownStyles` has been modified slightly so that it continues to display in the center.

Bump React component to latest version of `@zendeskgarden/react-loaders`

## References
[Github Issue]https://github.com/zendesk/volunteer_portal/issues/509

## CCs

@zendesk/volunteer


## Risks (if any)
* Low: Some spinners might not style correctly but should not affect functionality. Ensure all components from react-loaders still load correctly.
