### PR TITLE
Fail tests if vendor/cache gems are missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: install dependencies
           command: |
             gem install bundler -v 1.17.3
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --local --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
             - ./vendor/bundle
@@ -53,7 +53,7 @@ jobs:
           name: install dependencies
           command:  |
             gem install bundler -v 1.17.3
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --local --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
             - ./vendor/bundle


### PR DESCRIPTION
## Description
Bundle install using `--local` flag to install from the `vendor/cache` gems instead of reaching out to the internet.

This will ensure the tests fail if `vendor/cache` gems are missing, rather than us merging in with a build that fails on deploy. It fails on deploy if gems are missing from `vendor/cache` as it's only getting gems from the `vendor/cache` directory. This will help us see the issue earlier as we're treating the build of the tests the same as the deploy.

## CCs
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* Low: this affects CI which will fail if not correct
