### PR TITLE
postgres in docker compatability: use TCP for postgres connection locally and tests

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,6 +23,7 @@ default: &default
 
 development:
   <<: *default
+  host: localhost
   username: volunteer
   database: volunteer_development
 
@@ -58,6 +59,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  host: localhost
   username: <%= ENV['PGUSER'] || 'volunteer' %>
   database: volunteer_test
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200506054322) do
+ActiveRecord::Schema.define(version: 2020_05_06_054322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/script/setup_db.sh
+++ b/script/setup_db.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eux
-psql -d postgres -c 'CREATE ROLE volunteer WITH LOGIN SUPERUSER'
+psql -h localhost -d postgres -c 'CREATE ROLE volunteer WITH LOGIN SUPERUSER'
 bundle exec ./bin/rails db:setup


### PR DESCRIPTION
Compatibility settings for running Postgres in docker locally:
- Adding host to the database.yml file will ensure the connection is over TCP.
- Update database setup script with host option

@zendesk/volunteer
