### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    vendor: true
+  - package-ecosystem: "npm"
+    directory: /
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION

## Description
Adding the dependabot.yml should reduce the frequency that dependabot checks for updates.
Monthly seems to the longest interval available according to the [docs.](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#scheduleinterval)

## Risks (if any)
* [Low] - Adding configuration for dependabot
