### PR TITLE
add default organization as External Volunteering

### DIFF
--- a/config/locales/en.csv
+++ b/config/locales/en.csv
@@ -214,7 +214,7 @@ volunteer_portal.admin.tab.user.myevents.individualevent.recordevent,Record Even
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.description,Description,,,true
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.description.error,Must not be empty,,,true
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization,Organization,,,true
-volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.hint,"Contact us to add your organization to this list or select 'Other'",,,true
+volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.hint,"If you do not see your organization, select 'External Volunteering'",,,true
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.error,Must select one,,,true
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.date,Date,,,true
 volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.date.error,Must select one,,,true

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -216,7 +216,7 @@
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.description": "Description",
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.description.error": "Must not be empty",
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization": "Organization",
-      "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.hint": "Contact us to add your organization to this list or select 'Other'",
+      "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.hint": "If you do not see your organization, select 'External Volunteering'",
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.organization.error": "Must select one",
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.date": "Date",
       "volunteer_portal.admin.tab.user.myevents.individualevent.recordevent.date.error": "Must select one",

--- a/db/migrate/20210630040854_default_external_organization.rb
+++ b/db/migrate/20210630040854_default_external_organization.rb
@@ -1,0 +1,5 @@
+class DefaultExternalOrganization < ActiveRecord::Migration[5.2]
+  def change
+    Organization.where(name: 'External Volunteering', description: 'A default option for unlisted organization', location: 'N/A').first_or_create
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_054322) do
+ActiveRecord::Schema.define(version: 2021_06_30_040854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
So when a user records an individual event, if the organization isn't listed in the list of organizations to select, they may choose this option.