### PR TITLE
Replace material LinearProgress with Garden Progress component

### DIFF
--- a/app/javascript/components/Event/index.js
+++ b/app/javascript/components/Event/index.js
@@ -1,19 +1,9 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Link } from 'react-router'
 import * as R from 'ramda'
-import LinearProgress from 'material-ui/LinearProgress'
+import { Progress } from '@zendeskgarden/react-loaders'
 
 import s from './main.css'
-
-// Material UI components still require inline styles
-const styles = {
-  bar: {
-    height: 7,
-    borderRadius: 4,
-    width: '100%',
-    backgroundColor: '#ddd',
-  },
-}
 
 const Container = ({ event, isLink, children, onClick }) => {
   // When this is rendered on the Calendar, we want it to trigger a popover. When it is
@@ -28,9 +18,7 @@ const Container = ({ event, isLink, children, onClick }) => {
 const Event = ({ event, isLink, addPopover, onClick }) => (
   <Container className={s.event} event={event} isLink={isLink} onClick={onClick}>
     <span className={s.title}>{event.title}</span>
-    <LinearProgress
-      style={styles.bar}
-      mode="determinate"
+    <Progress
       value={(R.clamp(0, 100, event.signupCount / event.capacity) || 0) * 100.0}
       color="#30aabc"
     />


### PR DESCRIPTION
## Description
Replacing the existing `LinearProgress` component with Garden's `Progress` component. 

_If you have a look at the screenshots, there is a clear difference between the two. I suspect the reason that Garden's component is displaying as a thinner bar than Material UI's component; is due to a parent div constraining the dimensions and `Progress` dynamically shrinking to fit it_

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/505)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/53738056/127271681-6aa309c6-92c5-4eda-acd3-fc8cee85ec8d.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/53738056/127271721-a5e3d6e4-47f0-4412-8d20-9e911fbcd775.png">
</details>

## Risks (if any)
* [low] - Non-functional change: replacing the material component with the garden version. 
