### PR TITLE
Set dependabot to only allow direct dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,11 @@ updates:
     schedule:
       interval: "monthly"
     vendor: true
+    allow:
+      - dependency-type: "direct"
   - package-ecosystem: "npm"
     directory: /
     schedule:
       interval: "monthly"
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
## Description
Dependabot is currently set to bump all dependencies. This could lead to a situation where only an indirect dependency is bumped, which introduces a breakage in a direct dependency, which can lead to breakages in the Portal. Refer to #614 for some more background.

This change limits dependabot to only upgrade direct dependencies.

## CCs

If app migration related
@zendesk/volunteer

## Risks (if any)
* Low - changes the behaviour of dependabot dependency upgrades
