### PR TITLE
Fix typo in office_id

### DIFF
--- a/app/graphql/types/input/edit_user_input_type.rb
+++ b/app/graphql/types/input/edit_user_input_type.rb
@@ -5,6 +5,6 @@ module Types::Input
 
     argument :id, ID, required: true
     argument :is_admin, Boolean, required: true
-    argument :officeId, ID, required: true
+    argument :office_id, ID, required: true
   end
 end


### PR DESCRIPTION
Short description

Where you cannot save updates to user profiles.

## Description
The naming convention for graphql fields in ruby is snake case. The `officeId` camel case is incorrect and prevents updating a user profile.

## References
[Github Issue](https://github.com/zendesk/volunteer_portal/issues/654)

## Implementation notes (if needed)
N/A

## Tasks (if needed)
- [ ] Write tests

## Screenshots (if needed)
N/A

## CCs

If app migration related
@zendesk/volunteer

Anyone specific?

## Risks (if any)
* [low] - If change is not done properly we can break the User profile edit section. there are very few lines of code. We have already tested this and seems to be working fine.